### PR TITLE
implemented auto-pickup on trample

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/HeroAction.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/HeroAction.java
@@ -24,68 +24,78 @@ package com.shatteredpixel.shatteredpixeldungeon.actors.hero;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 
 public class HeroAction {
-	
-	public int dst;
-	
-	public static class Move extends HeroAction {
-		public Move( int dst ) {
-			this.dst = dst;
-		}
-	}
-	
-	public static class PickUp extends HeroAction {
-		public PickUp( int dst ) {
-			this.dst = dst;
-		}
-	}
-	
-	public static class OpenChest extends HeroAction {
-		public OpenChest( int dst ) {
-			this.dst = dst;
-		}
-	}
-	
-	public static class Buy extends HeroAction {
-		public Buy( int dst ) {
-			this.dst = dst;
-		}
-	}
-	
-	public static class Interact extends HeroAction {
-		public Char ch;
-		public Interact( Char ch ) {
-			this.ch = ch;
-		}
-	}
-	
-	public static class Unlock extends HeroAction {
-		public Unlock( int door ) {
-			this.dst = door;
-		}
-	}
-	
-	public static class LvlTransition extends HeroAction {
-		public LvlTransition(int stairs ) {
-			this.dst = stairs;
-		}
-	}
 
-	public static class Mine extends HeroAction {
-		public Mine( int wall ) {
-			this.dst = wall;
-		}
-	}
-	
-	public static class Alchemy extends HeroAction {
-		public Alchemy( int pot ) {
-			this.dst = pot;
-		}
-	}
-	
-	public static class Attack extends HeroAction {
-		public Char target;
-		public Attack( Char target ) {
-			this.target = target;
-		}
-	}
+    public int dst;
+
+    public static class Move extends HeroAction {
+        public Move(int dst) {
+            this.dst = dst;
+        }
+    }
+
+    public static class PickUp extends HeroAction {
+        public boolean isAutoLoot;
+
+        public PickUp(int dst, boolean isAutoLoot) {
+            this.dst = dst;
+            this.isAutoLoot = isAutoLoot;
+        }
+
+        public PickUp(int dst) {
+            this.dst = dst;
+            this.isAutoLoot = false;
+        }
+    }
+
+    public static class OpenChest extends HeroAction {
+        public OpenChest(int dst) {
+            this.dst = dst;
+        }
+    }
+
+    public static class Buy extends HeroAction {
+        public Buy(int dst) {
+            this.dst = dst;
+        }
+    }
+
+    public static class Interact extends HeroAction {
+        public Char ch;
+
+        public Interact(Char ch) {
+            this.ch = ch;
+        }
+    }
+
+    public static class Unlock extends HeroAction {
+        public Unlock(int door) {
+            this.dst = door;
+        }
+    }
+
+    public static class LvlTransition extends HeroAction {
+        public LvlTransition(int stairs) {
+            this.dst = stairs;
+        }
+    }
+
+    public static class Mine extends HeroAction {
+        public Mine(int wall) {
+            this.dst = wall;
+        }
+    }
+
+    public static class Alchemy extends HeroAction {
+        public Alchemy(int pot) {
+            this.dst = pot;
+        }
+    }
+
+    public static class Attack extends HeroAction {
+        public Char target;
+
+        public Attack(Char target) {
+            this.target = target;
+        }
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Blacksmith.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/npcs/Blacksmith.java
@@ -54,294 +54,295 @@ import com.watabou.utils.Random;
 import java.util.ArrayList;
 
 public class Blacksmith extends NPC {
-	
-	{
-		spriteClass = BlacksmithSprite.class;
 
-		properties.add(Property.IMMOVABLE);
-	}
-	
-	@Override
-	protected boolean act() {
-		if (Dungeon.hero.buff(AscensionChallenge.class) != null){
-			die(null);
-			return true;
-		}
-		if (Dungeon.level.visited[pos] && !Quest.reforged){
-			Notes.add( Notes.Landmark.TROLL );
-		}
-		return super.act();
-	}
-	
-	@Override
-	public boolean interact(Char c) {
-		
-		sprite.turnTo( pos, c.pos );
+    {
+        spriteClass = BlacksmithSprite.class;
 
-		if (c != Dungeon.hero){
-			return true;
-		}
-		
-		if (!Quest.given) {
-			
-			Game.runOnRenderThread(new Callback() {
-				@Override
-				public void call() {
-					GameScene.show( new WndQuest( Blacksmith.this,
-							Quest.alternative ? Messages.get(Blacksmith.this, "blood_1") : Messages.get(Blacksmith.this, "gold_1") ) {
-						
-						@Override
-						public void onBackPressed() {
-							super.onBackPressed();
-							
-							Quest.given = true;
-							Quest.completed = false;
-							Notes.add( Notes.Landmark.TROLL );
-							
-							Pickaxe pick = new Pickaxe();
-							pick.identify();
-							if (pick.doPickUp( Dungeon.hero )) {
-								GLog.i( Messages.capitalize(Messages.get(Dungeon.hero, "you_now_have", pick.name()) ));
-							} else {
-								Dungeon.level.drop( pick, Dungeon.hero.pos ).sprite.drop();
-							}
-						}
-					} );
-				}
-			});
-			
-		} else if (!Quest.completed) {
-			if (Quest.alternative) {
-				
-				Pickaxe pick = Dungeon.hero.belongings.getItem( Pickaxe.class );
-				if (pick == null) {
-					tell( Messages.get(this, "lost_pick") );
-				} else if (!pick.bloodStained) {
-					tell( Messages.get(this, "blood_2") );
-				} else {
-					if (pick.isEquipped( Dungeon.hero )) {
-						pick.cursed = false; //so that it can always be removed
-						pick.doUnequip( Dungeon.hero, false );
-					}
-					pick.detach( Dungeon.hero.belongings.backpack );
-					tell( Messages.get(this, "completed") );
-					
-					Quest.completed = true;
-					Quest.reforged = false;
-					Statistics.questScores[2] = 3000;
-				}
-				
-			} else {
-				
-				Pickaxe pick = Dungeon.hero.belongings.getItem( Pickaxe.class );
-				DarkGold gold = Dungeon.hero.belongings.getItem( DarkGold.class );
-				if (pick == null) {
-					tell( Messages.get(this, "lost_pick") );
-				} else if (gold == null || gold.quantity() < 15) {
-					tell( Messages.get(this, "gold_2") );
-				} else {
-					if (pick.isEquipped( Dungeon.hero )) {
-						pick.doUnequip( Dungeon.hero, false );
-					}
-					pick.detach( Dungeon.hero.belongings.backpack );
-					gold.detachAll( Dungeon.hero.belongings.backpack );
-					tell( Messages.get(this, "completed") );
-					
-					Quest.completed = true;
-					Quest.reforged = false;
-					Statistics.questScores[2] = 3000;
-				}
-				
-			}
-		} else if (!Quest.reforged) {
-			
-			Game.runOnRenderThread(new Callback() {
-				@Override
-				public void call() {
-					GameScene.show( new WndBlacksmith( Blacksmith.this, Dungeon.hero ) );
-				}
-			});
-			
-		} else {
-			
-			tell( Messages.get(this, "get_lost") );
-			
-		}
+        properties.add(Property.IMMOVABLE);
+    }
 
-		return true;
-	}
-	
-	private void tell( String text ) {
-		Game.runOnRenderThread(new Callback() {
-			@Override
-			public void call() {
-				GameScene.show( new WndQuest( Blacksmith.this, text ) );
-			}
-		});
-	}
-	
-	public static String verify( Item item1, Item item2 ) {
-		
-		if (item1 == item2 && (item1.quantity() == 1 && item2.quantity() == 1)) {
-			return Messages.get(Blacksmith.class, "same_item");
-		}
+    @Override
+    protected boolean act() {
+        if (Dungeon.hero.buff(AscensionChallenge.class) != null) {
+            die(null);
+            return true;
+        }
+        if (Dungeon.level.visited[pos] && !Quest.reforged) {
+            Notes.add(Notes.Landmark.TROLL);
+        }
+        return super.act();
+    }
 
-		if (item1.getClass() != item2.getClass()) {
-			return Messages.get(Blacksmith.class, "diff_type");
-		}
-		
-		if (!item1.isIdentified() || !item2.isIdentified()) {
-			return Messages.get(Blacksmith.class, "un_ided");
-		}
-		
-		if (item1.cursed || item2.cursed ||
-				(item1 instanceof Armor && ((Armor) item1).hasCurseGlyph()) ||
-				(item2 instanceof Armor && ((Armor) item2).hasCurseGlyph()) ||
-				(item1 instanceof Weapon && ((Weapon) item1).hasCurseEnchant()) ||
-				(item2 instanceof Weapon && ((Weapon) item2).hasCurseEnchant())) {
-			return Messages.get(Blacksmith.class, "cursed");
-		}
-		
-		if (item1.level() < 0 || item2.level() < 0) {
-			return Messages.get(Blacksmith.class, "degraded");
-		}
-		
-		if (!item1.isUpgradable() || !item2.isUpgradable()) {
-			return Messages.get(Blacksmith.class, "cant_reforge");
-		}
-		
-		return null;
-	}
-	
-	public static void upgrade( Item item1, Item item2 ) {
-		
-		Item first, second;
-		if (item2.trueLevel() > item1.trueLevel()) {
-			first = item2;
-			second = item1;
-		} else {
-			first = item1;
-			second = item2;
-		}
+    @Override
+    public boolean interact(Char c) {
 
-		Sample.INSTANCE.play( Assets.Sounds.EVOKE );
-		ScrollOfUpgrade.upgrade( Dungeon.hero );
-		Item.evoke( Dungeon.hero );
+        sprite.turnTo(pos, c.pos);
 
-		if (second.isEquipped( Dungeon.hero )) {
-			((EquipableItem)second).doUnequip( Dungeon.hero, false );
-		}
-		second.detach( Dungeon.hero.belongings.backpack );
+        if (c != Dungeon.hero) {
+            return true;
+        }
 
-		if (second instanceof Armor){
-			BrokenSeal seal = ((Armor) second).checkSeal();
-			if (seal != null){
-				Dungeon.level.drop( seal, Dungeon.hero.pos );
-			}
-		}
+        if (!Quest.given) {
 
-		//preserves enchant/glyphs if present
-		if (first instanceof Weapon && ((Weapon) first).hasGoodEnchant()){
-			((Weapon) first).upgrade(true);
-		} else if (first instanceof Armor && ((Armor) first).hasGoodGlyph()){
-			((Armor) first).upgrade(true);
-		} else {
-			first.upgrade();
-		}
-		Dungeon.hero.spendAndNext( 2f );
-		Badges.validateItemLevelAquired( first );
-		Item.updateQuickslot();
-		
-		Quest.reforged = true;
-		
-		Notes.remove( Notes.Landmark.TROLL );
-	}
-	
-	@Override
-	public int defenseSkill( Char enemy ) {
-		return INFINITE_EVASION;
-	}
-	
-	@Override
-	public void damage( int dmg, Object src ) {
-		//do nothing
-	}
+            Game.runOnRenderThread(new Callback() {
+                @Override
+                public void call() {
+                    GameScene.show(new WndQuest(Blacksmith.this,
+                            Quest.alternative ? Messages.get(Blacksmith.this, "blood_1")
+                                    : Messages.get(Blacksmith.this, "gold_1")) {
 
-	@Override
-	public boolean add( Buff buff ) {
-		return false;
-	}
-	
-	@Override
-	public boolean reset() {
-		return true;
-	}
+                        @Override
+                        public void onBackPressed() {
+                            super.onBackPressed();
 
-	public static class Quest {
-		
-		private static boolean spawned;
-		
-		private static boolean alternative;
-		private static boolean given;
-		private static boolean completed;
-		private static boolean reforged;
-		
-		public static void reset() {
-			spawned		= false;
-			given		= false;
-			completed	= false;
-			reforged	= false;
-		}
-		
-		private static final String NODE	= "blacksmith";
-		
-		private static final String SPAWNED		= "spawned";
-		private static final String ALTERNATIVE	= "alternative";
-		private static final String GIVEN		= "given";
-		private static final String COMPLETED	= "completed";
-		private static final String REFORGED	= "reforged";
-		
-		public static void storeInBundle( Bundle bundle ) {
-			
-			Bundle node = new Bundle();
-			
-			node.put( SPAWNED, spawned );
-			
-			if (spawned) {
-				node.put( ALTERNATIVE, alternative );
-				node.put( GIVEN, given );
-				node.put( COMPLETED, completed );
-				node.put( REFORGED, reforged );
-			}
-			
-			bundle.put( NODE, node );
-		}
-		
-		public static void restoreFromBundle( Bundle bundle ) {
+                            Quest.given = true;
+                            Quest.completed = false;
+                            Notes.add(Notes.Landmark.TROLL);
 
-			Bundle node = bundle.getBundle( NODE );
-			
-			if (!node.isNull() && (spawned = node.getBoolean( SPAWNED ))) {
-				alternative	=  node.getBoolean( ALTERNATIVE );
-				given = node.getBoolean( GIVEN );
-				completed = node.getBoolean( COMPLETED );
-				reforged = node.getBoolean( REFORGED );
-			} else {
-				reset();
-			}
-		}
-		
-		public static ArrayList<Room> spawn( ArrayList<Room> rooms ) {
-			if (!spawned && Dungeon.depth > 11 && Random.Int( 15 - Dungeon.depth ) == 0) {
-				
-				rooms.add(new BlacksmithRoom());
-				spawned = true;
-				alternative = Random.Int( 2 ) == 0;
-				
-				given = false;
-				
-			}
-			return rooms;
-		}
-	}
+                            Pickaxe pick = new Pickaxe();
+                            pick.identify();
+                            if (pick.doPickUp(Dungeon.hero)) {
+                                GLog.i(Messages.capitalize(Messages.get(Dungeon.hero, "you_now_have", pick.name())));
+                            } else {
+                                Dungeon.level.drop(pick, Dungeon.hero.pos).sprite.drop();
+                            }
+                        }
+                    });
+                }
+            });
+
+        } else if (!Quest.completed) {
+            if (Quest.alternative) {
+
+                Pickaxe pick = Dungeon.hero.belongings.getItem(Pickaxe.class);
+                if (pick == null) {
+                    tell(Messages.get(this, "lost_pick"));
+                } else if (!pick.bloodStained) {
+                    tell(Messages.get(this, "blood_2"));
+                } else {
+                    if (pick.isEquipped(Dungeon.hero)) {
+                        pick.cursed = false; // so that it can always be removed
+                        pick.doUnequip(Dungeon.hero, false);
+                    }
+                    pick.detach(Dungeon.hero.belongings.backpack);
+                    tell(Messages.get(this, "completed"));
+
+                    Quest.completed = true;
+                    Quest.reforged = false;
+                    Statistics.questScores[2] = 3000;
+                }
+
+            } else {
+
+                Pickaxe pick = Dungeon.hero.belongings.getItem(Pickaxe.class);
+                DarkGold gold = Dungeon.hero.belongings.getItem(DarkGold.class);
+                if (pick == null) {
+                    tell(Messages.get(this, "lost_pick"));
+                } else if (gold == null || gold.quantity() < 15) {
+                    tell(Messages.get(this, "gold_2"));
+                } else {
+                    if (pick.isEquipped(Dungeon.hero)) {
+                        pick.doUnequip(Dungeon.hero, false);
+                    }
+                    pick.detach(Dungeon.hero.belongings.backpack);
+                    gold.detachAll(Dungeon.hero.belongings.backpack);
+                    tell(Messages.get(this, "completed"));
+
+                    Quest.completed = true;
+                    Quest.reforged = false;
+                    Statistics.questScores[2] = 3000;
+                }
+
+            }
+        } else if (!Quest.reforged) {
+
+            Game.runOnRenderThread(new Callback() {
+                @Override
+                public void call() {
+                    GameScene.show(new WndBlacksmith(Blacksmith.this, Dungeon.hero));
+                }
+            });
+
+        } else {
+
+            tell(Messages.get(this, "get_lost"));
+
+        }
+
+        return true;
+    }
+
+    private void tell(String text) {
+        Game.runOnRenderThread(new Callback() {
+            @Override
+            public void call() {
+                GameScene.show(new WndQuest(Blacksmith.this, text));
+            }
+        });
+    }
+
+    public static String verify(Item item1, Item item2) {
+
+        if (item1 == item2 && (item1.quantity() == 1 && item2.quantity() == 1)) {
+            return Messages.get(Blacksmith.class, "same_item");
+        }
+
+        if (item1.getClass() != item2.getClass()) {
+            return Messages.get(Blacksmith.class, "diff_type");
+        }
+
+        if (!item1.isIdentified() || !item2.isIdentified()) {
+            return Messages.get(Blacksmith.class, "un_ided");
+        }
+
+        if (item1.cursed || item2.cursed ||
+                (item1 instanceof Armor && ((Armor) item1).hasCurseGlyph()) ||
+                (item2 instanceof Armor && ((Armor) item2).hasCurseGlyph()) ||
+                (item1 instanceof Weapon && ((Weapon) item1).hasCurseEnchant()) ||
+                (item2 instanceof Weapon && ((Weapon) item2).hasCurseEnchant())) {
+            return Messages.get(Blacksmith.class, "cursed");
+        }
+
+        if (item1.level() < 0 || item2.level() < 0) {
+            return Messages.get(Blacksmith.class, "degraded");
+        }
+
+        if (!item1.isUpgradable() || !item2.isUpgradable()) {
+            return Messages.get(Blacksmith.class, "cant_reforge");
+        }
+
+        return null;
+    }
+
+    public static void upgrade(Item item1, Item item2) {
+
+        Item first, second;
+        if (item2.trueLevel() > item1.trueLevel()) {
+            first = item2;
+            second = item1;
+        } else {
+            first = item1;
+            second = item2;
+        }
+
+        Sample.INSTANCE.play(Assets.Sounds.EVOKE);
+        ScrollOfUpgrade.upgrade(Dungeon.hero);
+        Item.evoke(Dungeon.hero);
+
+        if (second.isEquipped(Dungeon.hero)) {
+            ((EquipableItem) second).doUnequip(Dungeon.hero, false);
+        }
+        second.detach(Dungeon.hero.belongings.backpack);
+
+        if (second instanceof Armor) {
+            BrokenSeal seal = ((Armor) second).checkSeal();
+            if (seal != null) {
+                Dungeon.level.drop(seal, Dungeon.hero.pos, true);
+            }
+        }
+
+        // preserves enchant/glyphs if present
+        if (first instanceof Weapon && ((Weapon) first).hasGoodEnchant()) {
+            ((Weapon) first).upgrade(true);
+        } else if (first instanceof Armor && ((Armor) first).hasGoodGlyph()) {
+            ((Armor) first).upgrade(true);
+        } else {
+            first.upgrade();
+        }
+        Dungeon.hero.spendAndNext(2f);
+        Badges.validateItemLevelAquired(first);
+        Item.updateQuickslot();
+
+        Quest.reforged = true;
+
+        Notes.remove(Notes.Landmark.TROLL);
+    }
+
+    @Override
+    public int defenseSkill(Char enemy) {
+        return INFINITE_EVASION;
+    }
+
+    @Override
+    public void damage(int dmg, Object src) {
+        // do nothing
+    }
+
+    @Override
+    public boolean add(Buff buff) {
+        return false;
+    }
+
+    @Override
+    public boolean reset() {
+        return true;
+    }
+
+    public static class Quest {
+
+        private static boolean spawned;
+
+        private static boolean alternative;
+        private static boolean given;
+        private static boolean completed;
+        private static boolean reforged;
+
+        public static void reset() {
+            spawned = false;
+            given = false;
+            completed = false;
+            reforged = false;
+        }
+
+        private static final String NODE = "blacksmith";
+
+        private static final String SPAWNED = "spawned";
+        private static final String ALTERNATIVE = "alternative";
+        private static final String GIVEN = "given";
+        private static final String COMPLETED = "completed";
+        private static final String REFORGED = "reforged";
+
+        public static void storeInBundle(Bundle bundle) {
+
+            Bundle node = new Bundle();
+
+            node.put(SPAWNED, spawned);
+
+            if (spawned) {
+                node.put(ALTERNATIVE, alternative);
+                node.put(GIVEN, given);
+                node.put(COMPLETED, completed);
+                node.put(REFORGED, reforged);
+            }
+
+            bundle.put(NODE, node);
+        }
+
+        public static void restoreFromBundle(Bundle bundle) {
+
+            Bundle node = bundle.getBundle(NODE);
+
+            if (!node.isNull() && (spawned = node.getBoolean(SPAWNED))) {
+                alternative = node.getBoolean(ALTERNATIVE);
+                given = node.getBoolean(GIVEN);
+                completed = node.getBoolean(COMPLETED);
+                reforged = node.getBoolean(REFORGED);
+            } else {
+                reset();
+            }
+        }
+
+        public static ArrayList<Room> spawn(ArrayList<Room> rooms) {
+            if (!spawned && Dungeon.depth > 11 && Random.Int(15 - Dungeon.depth) == 0) {
+
+                rooms.add(new BlacksmithRoom());
+                spawned = true;
+                alternative = Random.Int(2) == 0;
+
+                given = false;
+
+            }
+            return rooms;
+        }
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Amulet.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Amulet.java
@@ -38,103 +38,102 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public class Amulet extends Item {
-	
-	private static final String AC_END = "END";
-	
-	{
-		image = ItemSpriteSheet.AMULET;
-		
-		unique = true;
-	}
-	
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		if (hero.buff(AscensionChallenge.class) != null){
-			actions.clear();
-		} else {
-			actions.add(AC_END);
-		}
-		return actions;
-	}
-	
-	@Override
-	public void execute( Hero hero, String action ) {
 
-		super.execute( hero, action );
+    private static final String AC_END = "END";
 
-		if (action.equals(AC_END)) {
-			showAmuletScene( false );
-		}
-	}
-	
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (super.doPickUp( hero, pos )) {
-			
-			if (!Statistics.amuletObtained) {
-				Statistics.amuletObtained = true;
-				hero.spend(-TIME_TO_PICK_UP);
+    {
+        image = ItemSpriteSheet.AMULET;
 
-				//add a delayed actor here so pickup behaviour can fully process.
-				Actor.addDelayed(new Actor(){
-					@Override
-					protected boolean act() {
-						Actor.remove(this);
-						showAmuletScene( true );
-						return false;
-					}
-				}, -5);
-			}
-			
-			return true;
-		} else {
-			return false;
-		}
-	}
-	
-	private void showAmuletScene( boolean showText ) {
-		AmuletScene.noText = !showText;
-		Game.switchScene( AmuletScene.class, new Game.SceneChangeCallback() {
-			@Override
-			public void beforeCreate() {
+        unique = true;
+    }
 
-			}
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        if (hero.buff(AscensionChallenge.class) != null) {
+            actions.clear();
+        } else {
+            actions.add(AC_END);
+        }
+        return actions;
+    }
 
-			@Override
-			public void afterCreate() {
-				Badges.validateVictory();
-				Badges.validateChampion(Challenges.activeChallenges());
-				try {
-					Dungeon.saveAll();
-					Badges.saveGlobal();
-				} catch (IOException e) {
-					ShatteredPixelDungeon.reportException(e);
-				}
-			}
-		});
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
+    @Override
+    public void execute(Hero hero, String action) {
 
-	@Override
-	public String desc() {
-		String desc = super.desc();
+        super.execute(hero, action);
 
-		if (Dungeon.hero.buff(AscensionChallenge.class) == null){
-			desc += "\n\n" + Messages.get(this, "desc_origins");
-		} else {
-			desc += "\n\n" + Messages.get(this, "desc_ascent");
-		}
+        if (action.equals(AC_END)) {
+            showAmuletScene(false);
+        }
+    }
 
-		return desc;
-	}
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (super.doPickUp(hero, pos, isAutoLoot)) {
+            if (!Statistics.amuletObtained) {
+                Statistics.amuletObtained = true;
+                if (!isAutoLoot)
+                    hero.spend(-TIME_TO_PICK_UP);
+
+                // add a delayed actor here so pickup behaviour can fully process.
+                Actor.addDelayed(new Actor() {
+                    @Override
+                    protected boolean act() {
+                        Actor.remove(this);
+                        showAmuletScene(true);
+                        return false;
+                    }
+                }, -5);
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void showAmuletScene(boolean showText) {
+        AmuletScene.noText = !showText;
+        Game.switchScene(AmuletScene.class, new Game.SceneChangeCallback() {
+            @Override
+            public void beforeCreate() {
+
+            }
+
+            @Override
+            public void afterCreate() {
+                Badges.validateVictory();
+                Badges.validateChampion(Challenges.activeChallenges());
+                try {
+                    Dungeon.saveAll();
+                    Badges.saveGlobal();
+                } catch (IOException e) {
+                    ShatteredPixelDungeon.reportException(e);
+                }
+            }
+        });
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public String desc() {
+        String desc = super.desc();
+
+        if (Dungeon.hero.buff(AscensionChallenge.class) == null) {
+            desc += "\n\n" + Messages.get(this, "desc_origins");
+        } else {
+            desc += "\n\n" + Messages.get(this, "desc_ascent");
+        }
+
+        return desc;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Dewdrop.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Dewdrop.java
@@ -37,97 +37,96 @@ import com.shatteredpixel.shatteredpixeldungeon.utils.GLog;
 import com.watabou.noosa.audio.Sample;
 
 public class Dewdrop extends Item {
-	
-	{
-		image = ItemSpriteSheet.DEWDROP;
-		
-		stackable = true;
-		dropsDownHeap = true;
-	}
-	
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		
-		Waterskin flask = hero.belongings.getItem( Waterskin.class );
-		
-		if (flask != null && !flask.isFull()){
 
-			flask.collectDew( this );
-			GameScene.pickUp( this, pos );
+    {
+        image = ItemSpriteSheet.DEWDROP;
 
-		} else {
+        stackable = true;
+        dropsDownHeap = true;
+    }
 
-			int terr = Dungeon.level.map[pos];
-			if (!consumeDew(1, hero, terr == Terrain.ENTRANCE|| terr == Terrain.EXIT || terr == Terrain.UNLOCKED_EXIT)){
-				return false;
-			}
-			
-		}
-		
-		Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-		hero.spendAndNext( TIME_TO_PICK_UP );
-		
-		return true;
-	}
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        Waterskin flask = hero.belongings.getItem(Waterskin.class);
 
-	public static boolean consumeDew(int quantity, Hero hero, boolean force){
-		//20 drops for a full heal
-		int heal = Math.round( hero.HT * 0.05f * quantity );
+        if (flask != null && !flask.isFull()) {
+            flask.collectDew(this);
+            GameScene.pickUp(this, pos);
+        } else {
+            int terr = Dungeon.level.map[pos];
+            if (!consumeDew(1, hero,
+                    terr == Terrain.ENTRANCE || terr == Terrain.EXIT || terr == Terrain.UNLOCKED_EXIT)) {
+                return false;
+            }
+        }
 
-		int effect = Math.min( hero.HT - hero.HP, heal );
-		int shield = 0;
-		if (hero.hasTalent(Talent.SHIELDING_DEW)){
-			shield = heal - effect;
-			int maxShield = Math.round(hero.HT *0.2f*hero.pointsInTalent(Talent.SHIELDING_DEW));
-			int curShield = 0;
-			if (hero.buff(Barrier.class) != null) curShield = hero.buff(Barrier.class).shielding();
-			shield = Math.min(shield, maxShield-curShield);
-		}
-		if (effect > 0 || shield > 0) {
-			hero.HP += effect;
-			if (shield > 0) Buff.affect(hero, Barrier.class).incShield(shield);
-			hero.sprite.emitter().burst( Speck.factory( Speck.HEALING ), 1 );
-			if (effect > 0 && shield > 0){
-				hero.sprite.showStatus( CharSprite.POSITIVE, Messages.get(Dewdrop.class, "both", effect, shield) );
-			} else if (effect > 0){
-				hero.sprite.showStatus( CharSprite.POSITIVE, Messages.get(Dewdrop.class, "heal", effect) );
-			} else {
-				hero.sprite.showStatus( CharSprite.POSITIVE, Messages.get(Dewdrop.class, "shield", shield) );
-			}
+        Sample.INSTANCE.play(Assets.Sounds.DEWDROP);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
 
-		} else if (!force) {
-			GLog.i( Messages.get(Dewdrop.class, "already_full") );
-			return false;
-		}
+        return true;
+    }
 
-		return true;
-	}
+    public static boolean consumeDew(int quantity, Hero hero, boolean force) {
+        // 20 drops for a full heal
+        int heal = Math.round(hero.HT * 0.05f * quantity);
 
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
+        int effect = Math.min(hero.HT - hero.HP, heal);
+        int shield = 0;
+        if (hero.hasTalent(Talent.SHIELDING_DEW)) {
+            shield = heal - effect;
+            int maxShield = Math.round(hero.HT * 0.2f * hero.pointsInTalent(Talent.SHIELDING_DEW));
+            int curShield = 0;
+            if (hero.buff(Barrier.class) != null)
+                curShield = hero.buff(Barrier.class).shielding();
+            shield = Math.min(shield, maxShield - curShield);
+        }
+        if (effect > 0 || shield > 0) {
+            hero.HP += effect;
+            if (shield > 0)
+                Buff.affect(hero, Barrier.class).incShield(shield);
+            hero.sprite.emitter().burst(Speck.factory(Speck.HEALING), 1);
+            if (effect > 0 && shield > 0) {
+                hero.sprite.showStatus(CharSprite.POSITIVE, Messages.get(Dewdrop.class, "both", effect, shield));
+            } else if (effect > 0) {
+                hero.sprite.showStatus(CharSprite.POSITIVE, Messages.get(Dewdrop.class, "heal", effect));
+            } else {
+                hero.sprite.showStatus(CharSprite.POSITIVE, Messages.get(Dewdrop.class, "shield", shield));
+            }
 
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
+        } else if (!force) {
+            GLog.i(Messages.get(Dewdrop.class, "already_full"));
+            return false;
+        }
 
-	//max of one dew in a stack
+        return true;
+    }
 
-	@Override
-	public Item merge( Item other ){
-		if (isSimilar( other )){
-			quantity = 1;
-			other.quantity = 0;
-		}
-		return this;
-	}
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
 
-	@Override
-	public Item quantity(int value) {
-		quantity = Math.min( value, 1);
-		return this;
-	}
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    // max of one dew in a stack
+
+    @Override
+    public Item merge(Item other) {
+        if (isSimilar(other)) {
+            quantity = 1;
+            other.quantity = 0;
+        }
+        return this;
+    }
+
+    @Override
+    public Item quantity(int value) {
+        quantity = Math.min(value, 1);
+        return this;
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EnergyCrystal.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EnergyCrystal.java
@@ -33,57 +33,58 @@ import java.util.ArrayList;
 
 public class EnergyCrystal extends Item {
 
-	private static final String TXT_VALUE	= "%+d";
+    private static final String TXT_VALUE = "%+d";
 
-	{
-		image = ItemSpriteSheet.ENERGY;
-		stackable = true;
-	}
+    {
+        image = ItemSpriteSheet.ENERGY;
+        stackable = true;
+    }
 
-	public EnergyCrystal() {
-		this( 1 );
-	}
+    public EnergyCrystal() {
+        this(1);
+    }
 
-	public EnergyCrystal( int value ) {
-		this.quantity = value;
-	}
+    public EnergyCrystal(int value) {
+        this.quantity = value;
+    }
 
-	@Override
-	public ArrayList<String> actions(Hero hero ) {
-		return new ArrayList<>();
-	}
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        return new ArrayList<>();
+    }
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        Dungeon.energy += quantity;
+        // TODO track energy collected maybe? We do already track recipes crafted
+        // though..
 
-		Dungeon.energy += quantity;
-		//TODO track energy collected maybe? We do already track recipes crafted though..
+        GameScene.pickUp(this, pos);
+        hero.sprite.showStatus(0x44CCFF, TXT_VALUE, quantity);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
 
-		GameScene.pickUp( this, pos );
-		hero.sprite.showStatus( 0x44CCFF, TXT_VALUE, quantity );
-		hero.spendAndNext( TIME_TO_PICK_UP );
+        Sample.INSTANCE.play(Assets.Sounds.ITEM);
 
-		Sample.INSTANCE.play( Assets.Sounds.ITEM );
+        updateQuickslot();
 
-		updateQuickslot();
+        return true;
+    }
 
-		return true;
-	}
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
 
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
 
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-
-	@Override
-	public Item random() {
-		quantity = Random.IntRange( 4, 6 );
-		return this;
-	}
+    @Override
+    public Item random() {
+        quantity = Random.IntRange(4, 6);
+        return this;
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EquipableItem.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EquipableItem.java
@@ -39,124 +39,128 @@ import java.util.ArrayList;
 
 public abstract class EquipableItem extends Item {
 
-	public static final String AC_EQUIP		= "EQUIP";
-	public static final String AC_UNEQUIP	= "UNEQUIP";
+    public static final String AC_EQUIP = "EQUIP";
+    public static final String AC_UNEQUIP = "UNEQUIP";
 
-	{
-		bones = true;
-	}
+    {
+        bones = true;
+    }
 
-	@Override
-	public ArrayList<String> actions(Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		actions.add( isEquipped( hero ) ? AC_UNEQUIP : AC_EQUIP );
-		return actions;
-	}
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        actions.add(isEquipped(hero) ? AC_UNEQUIP : AC_EQUIP);
+        return actions;
+    }
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (super.doPickUp(hero, pos)){
-			if (!isIdentified() && !Document.ADVENTURERS_GUIDE.isPageRead(Document.GUIDE_IDING)){
-				GLog.p(Messages.get(Guidebook.class, "hint"));
-				GameScene.flashForDocument(Document.ADVENTURERS_GUIDE, Document.GUIDE_IDING);
-			}
-			return true;
-		} else {
-			return false;
-		}
-	}
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (super.doPickUp(hero, pos, isAutoLoot)) {
+            if (!isIdentified() && !Document.ADVENTURERS_GUIDE.isPageRead(Document.GUIDE_IDING)) {
+                GLog.p(Messages.get(Guidebook.class, "hint"));
+                GameScene.flashForDocument(Document.ADVENTURERS_GUIDE, Document.GUIDE_IDING);
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	protected static int slotOfUnequipped = -1;
+    protected static int slotOfUnequipped = -1;
 
-	@Override
-	public void execute( Hero hero, String action ) {
+    @Override
+    public void execute(Hero hero, String action) {
 
-		super.execute( hero, action );
+        super.execute(hero, action);
 
-		if (action.equals( AC_EQUIP )) {
-			//In addition to equipping itself, item reassigns itself to the quickslot
-			//This is a special case as the item is being removed from inventory, but is staying with the hero.
-			int slot = Dungeon.quickslot.getSlot( this );
-			slotOfUnequipped = -1;
-			doEquip(hero);
-			if (slot != -1) {
-				Dungeon.quickslot.setSlot( slot, this );
-				updateQuickslot();
-			//if this item wasn't quickslotted, but the item it is replacing as equipped was
-			//then also have the item occupy the unequipped item's quickslot
-			} else if (slotOfUnequipped != -1 && defaultAction() != null) {
-				Dungeon.quickslot.setSlot( slotOfUnequipped, this );
-				updateQuickslot();
-			}
-		} else if (action.equals( AC_UNEQUIP )) {
-			doUnequip( hero, true );
-		}
-	}
+        if (action.equals(AC_EQUIP)) {
+            // In addition to equipping itself, item reassigns itself to the quickslot
+            // This is a special case as the item is being removed from inventory, but is
+            // staying with the hero.
+            int slot = Dungeon.quickslot.getSlot(this);
+            slotOfUnequipped = -1;
+            doEquip(hero);
+            if (slot != -1) {
+                Dungeon.quickslot.setSlot(slot, this);
+                updateQuickslot();
+                // if this item wasn't quickslotted, but the item it is replacing as equipped
+                // was
+                // then also have the item occupy the unequipped item's quickslot
+            } else if (slotOfUnequipped != -1 && defaultAction() != null) {
+                Dungeon.quickslot.setSlot(slotOfUnequipped, this);
+                updateQuickslot();
+            }
+        } else if (action.equals(AC_UNEQUIP)) {
+            doUnequip(hero, true);
+        }
+    }
 
-	@Override
-	public void doDrop( Hero hero ) {
-		if (!isEquipped( hero ) || doUnequip( hero, false, false )) {
-			super.doDrop( hero );
-		}
-	}
+    @Override
+    public void doDrop(Hero hero) {
+        if (!isEquipped(hero) || doUnequip(hero, false, false)) {
+            super.doDrop(hero);
+        }
+    }
 
-	@Override
-	public void cast( final Hero user, int dst ) {
+    @Override
+    public void cast(final Hero user, int dst) {
 
-		if (isEquipped( user )) {
-			if (quantity == 1 && !this.doUnequip( user, false, false )) {
-				return;
-			}
-		}
+        if (isEquipped(user)) {
+            if (quantity == 1 && !this.doUnequip(user, false, false)) {
+                return;
+            }
+        }
 
-		super.cast( user, dst );
-	}
+        super.cast(user, dst);
+    }
 
-	public static void equipCursed( Hero hero ) {
-		hero.sprite.emitter().burst( ShadowParticle.CURSE, 6 );
-		Sample.INSTANCE.play( Assets.Sounds.CURSED );
-	}
+    public static void equipCursed(Hero hero) {
+        hero.sprite.emitter().burst(ShadowParticle.CURSE, 6);
+        Sample.INSTANCE.play(Assets.Sounds.CURSED);
+    }
 
-	protected float time2equip( Hero hero ) {
-		return 1;
-	}
+    protected float time2equip(Hero hero) {
+        return 1;
+    }
 
-	public abstract boolean doEquip( Hero hero );
+    public abstract boolean doEquip(Hero hero);
 
-	public boolean doUnequip( Hero hero, boolean collect, boolean single ) {
+    public boolean doUnequip(Hero hero, boolean collect, boolean single) {
 
-		if (cursed
-				&& hero.buff(MagicImmune.class) == null
-				&& (hero.buff(LostInventory.class) == null || keptThoughLostInvent)) {
-			GLog.w(Messages.get(EquipableItem.class, "unequip_cursed"));
-			return false;
-		}
+        if (cursed
+                && hero.buff(MagicImmune.class) == null
+                && (hero.buff(LostInventory.class) == null || keptThoughLostInvent)) {
+            GLog.w(Messages.get(EquipableItem.class, "unequip_cursed"));
+            return false;
+        }
 
-		if (single) {
-			hero.spendAndNext( time2equip( hero ) );
-		} else {
-			hero.spend( time2equip( hero ) );
-		}
+        if (single) {
+            hero.spendAndNext(time2equip(hero));
+        } else {
+            hero.spend(time2equip(hero));
+        }
 
-		slotOfUnequipped = Dungeon.quickslot.getSlot(this);
+        slotOfUnequipped = Dungeon.quickslot.getSlot(this);
 
-		//temporarily keep this item so it can be collected
-		boolean wasKept = keptThoughLostInvent;
-		keptThoughLostInvent = true;
-		if (!collect || !collect( hero.belongings.backpack )) {
-			onDetach();
-			Dungeon.quickslot.clearItem(this);
-			updateQuickslot();
-			if (collect) Dungeon.level.drop( this, hero.pos ).sprite.drop();
-		}
-		keptThoughLostInvent = wasKept;
+        // temporarily keep this item so it can be collected
+        boolean wasKept = keptThoughLostInvent;
+        keptThoughLostInvent = true;
+        if (!collect || !collect(hero.belongings.backpack)) {
+            onDetach();
+            Dungeon.quickslot.clearItem(this);
+            updateQuickslot();
+            if (collect)
+                Dungeon.level.drop(this, hero.pos).sprite.drop();
+        }
+        keptThoughLostInvent = wasKept;
 
-		return true;
-	}
+        return true;
+    }
 
-	final public boolean doUnequip( Hero hero, boolean collect ) {
-		return doUnequip( hero, collect, true );
-	}
+    final public boolean doUnequip(Hero hero, boolean collect) {
+        return doUnequip(hero, collect, true);
+    }
 
-	public void activate( Char ch ){}
+    public void activate(Char ch) {
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Gold.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Gold.java
@@ -36,57 +36,57 @@ import java.util.ArrayList;
 
 public class Gold extends Item {
 
-	private static final String TXT_VALUE	= "%+d";
-	
-	{
-		image = ItemSpriteSheet.GOLD;
-		stackable = true;
-	}
-	
-	public Gold() {
-		this( 1 );
-	}
-	
-	public Gold( int value ) {
-		this.quantity = value;
-	}
-	
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		return new ArrayList<>();
-	}
-	
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		
-		Dungeon.gold += quantity;
-		Statistics.goldCollected += quantity;
-		Badges.validateGoldCollected();
+    private static final String TXT_VALUE = "%+d";
 
-		GameScene.pickUp( this, pos );
-		hero.sprite.showStatus( CharSprite.NEUTRAL, TXT_VALUE, quantity );
-		hero.spendAndNext( TIME_TO_PICK_UP );
-		
-		Sample.INSTANCE.play( Assets.Sounds.GOLD, 1, 1, Random.Float( 0.9f, 1.1f ) );
-		updateQuickslot();
-		
-		return true;
-	}
-	
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	@Override
-	public Item random() {
-		quantity = Random.IntRange( 30 + Dungeon.depth * 10, 60 + Dungeon.depth * 20 );
-		return this;
-	}
+    {
+        image = ItemSpriteSheet.GOLD;
+        stackable = true;
+    }
+
+    public Gold() {
+        this(1);
+    }
+
+    public Gold(int value) {
+        this.quantity = value;
+    }
+
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        Dungeon.gold += quantity;
+        Statistics.goldCollected += quantity;
+        Badges.validateGoldCollected();
+
+        GameScene.pickUp(this, pos);
+        hero.sprite.showStatus(CharSprite.NEUTRAL, TXT_VALUE, quantity);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
+
+        Sample.INSTANCE.play(Assets.Sounds.GOLD, 1, 1, Random.Float(0.9f, 1.1f));
+        updateQuickslot();
+
+        return true;
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    @Override
+    public Item random() {
+        quantity = Random.IntRange(30 + Dungeon.depth * 10, 60 + Dungeon.depth * 20);
+        return this;
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Honeypot.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Honeypot.java
@@ -39,216 +39,218 @@ import com.watabou.utils.Random;
 import java.util.ArrayList;
 
 public class Honeypot extends Item {
-	
-	public static final String AC_SHATTER	= "SHATTER";
-	
-	{
-		image = ItemSpriteSheet.HONEYPOT;
 
-		defaultAction = AC_THROW;
-		usesTargeting = true;
+    public static final String AC_SHATTER = "SHATTER";
 
-		stackable = true;
-	}
-	
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		actions.add( AC_SHATTER );
-		return actions;
-	}
-	
-	@Override
-	public void execute( final Hero hero, String action ) {
+    {
+        image = ItemSpriteSheet.HONEYPOT;
 
-		super.execute( hero, action );
+        defaultAction = AC_THROW;
+        usesTargeting = true;
 
-		if (action.equals( AC_SHATTER )) {
-			
-			hero.sprite.zap( hero.pos );
-			
-			detach( hero.belongings.backpack );
+        stackable = true;
+    }
 
-			Item item = shatter( hero, hero.pos );
-			if (!item.collect()){
-				Dungeon.level.drop(item, hero.pos);
-				if (item instanceof ShatteredPot){
-					((ShatteredPot) item).dropPot(hero, hero.pos);
-				}
-			}
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        actions.add(AC_SHATTER);
+        return actions;
+    }
 
-			hero.next();
+    @Override
+    public void execute(final Hero hero, String action) {
 
-		}
-	}
-	
-	@Override
-	protected void onThrow( int cell ) {
-		if (Dungeon.level.pit[cell]) {
-			super.onThrow( cell );
-		} else {
-			Dungeon.level.drop(shatter( null, cell ), cell);
-		}
-	}
-	
-	public Item shatter( Char owner, int pos ) {
-		
-		if (Dungeon.level.heroFOV[pos]) {
-			Sample.INSTANCE.play( Assets.Sounds.SHATTER );
-			Splash.at( pos, 0xffd500, 5 );
-		}
-		
-		int newPos = pos;
-		if (Actor.findChar( pos ) != null) {
-			ArrayList<Integer> candidates = new ArrayList<>();
-			
-			for (int n : PathFinder.NEIGHBOURS4) {
-				int c = pos + n;
-				if (!Dungeon.level.solid[c] && Actor.findChar( c ) == null) {
-					candidates.add( c );
-				}
-			}
-	
-			newPos = candidates.size() > 0 ? Random.element( candidates ) : -1;
-		}
-		
-		if (newPos != -1) {
-			Bee bee = new Bee();
-			bee.spawn( Dungeon.scalingDepth() );
-			bee.setPotInfo( pos, owner );
-			bee.HP = bee.HT;
-			bee.pos = newPos;
-			
-			GameScene.add( bee );
-			if (newPos != pos) Actor.addDelayed( new Pushing( bee, pos, newPos ), -1f );
+        super.execute(hero, action);
 
-			bee.sprite.alpha( 0 );
-			bee.sprite.parent.add( new AlphaTweener( bee.sprite, 1, 0.15f ) );
-			
-			Sample.INSTANCE.play( Assets.Sounds.BEE );
-			return new ShatteredPot();
-		} else {
-			return this;
-		}
-	}
-	
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	@Override
-	public int value() {
-		return 30 * quantity;
-	}
+        if (action.equals(AC_SHATTER)) {
 
-	//The bee's broken 'home', all this item does is let its bee know where it is, and who owns it (if anyone).
-	public static class ShatteredPot extends Item {
+            hero.sprite.zap(hero.pos);
 
-		{
-			image = ItemSpriteSheet.SHATTPOT;
-			stackable = true;
-		}
+            detach(hero.belongings.backpack);
 
-		@Override
-		public boolean doPickUp(Hero hero, int pos) {
-			if ( super.doPickUp(hero, pos) ){
-				pickupPot( hero );
-				return true;
-			} else {
-				return false;
-			}
-		}
+            Item item = shatter(hero, hero.pos);
+            if (!item.collect()) {
+                Dungeon.level.drop(item, hero.pos);
+                if (item instanceof ShatteredPot) {
+                    ((ShatteredPot) item).dropPot(hero, hero.pos);
+                }
+            }
 
-		@Override
-		public void doDrop(Hero hero) {
-			super.doDrop(hero);
-			dropPot(hero, hero.pos);
-		}
+            hero.next();
 
-		@Override
-		protected void onThrow(int cell) {
-			super.onThrow(cell);
-			dropPot(curUser, cell);
-		}
+        }
+    }
 
-		public void pickupPot(Char holder){
-			for (Bee bee : findBees(holder.pos)){
-				updateBee(bee, -1, holder);
-			}
-		}
-		
-		public void dropPot( Char holder, int dropPos ){
-			for (Bee bee : findBees(holder)){
-				updateBee(bee, dropPos, null);
-			}
-		}
+    @Override
+    protected void onThrow(int cell) {
+        if (Dungeon.level.pit[cell]) {
+            super.onThrow(cell);
+        } else {
+            Dungeon.level.drop(shatter(null, cell), cell);
+        }
+    }
 
-		public void movePot( int oldpos, int movePos){
-			for (Bee bee : findBees(oldpos)){
-				updateBee(bee, movePos, null);
-			}
-		}
+    public Item shatter(Char owner, int pos) {
 
-		public void destroyPot( int potPos ){
-			for (Bee bee : findBees(potPos)){
-				updateBee(bee, -1, null);
-			}
-		}
+        if (Dungeon.level.heroFOV[pos]) {
+            Sample.INSTANCE.play(Assets.Sounds.SHATTER);
+            Splash.at(pos, 0xffd500, 5);
+        }
 
-		private void updateBee( Bee bee, int cell, Char holder ){
-			if (bee != null && bee.alignment == Char.Alignment.ENEMY)
-				bee.setPotInfo( cell, holder );
-		}
-		
-		//returns up to quantity bees which match the current pot Pos
-		private ArrayList<Bee> findBees( int potPos ){
-			ArrayList<Bee> bees = new ArrayList<>();
-			for (Char c : Actor.chars()){
-				if (c instanceof Bee && ((Bee) c).potPos() == potPos){
-					bees.add((Bee) c);
-					if (bees.size() >= quantity) {
-						break;
-					}
-				}
-			}
-			
-			return bees;
-		}
-		
-		//returns up to quantity bees which match the current pot holder
-		private ArrayList<Bee> findBees( Char potHolder ){
-			ArrayList<Bee> bees = new ArrayList<>();
-			for (Char c : Actor.chars()){
-				if (c instanceof Bee && ((Bee) c).potHolderID() == potHolder.id()){
-					bees.add((Bee) c);
-					if (bees.size() >= quantity) {
-						break;
-					}
-				}
-			}
-			
-			return bees;
-		}
+        int newPos = pos;
+        if (Actor.findChar(pos) != null) {
+            ArrayList<Integer> candidates = new ArrayList<>();
 
-		@Override
-		public boolean isUpgradable() {
-			return false;
-		}
+            for (int n : PathFinder.NEIGHBOURS4) {
+                int c = pos + n;
+                if (!Dungeon.level.solid[c] && Actor.findChar(c) == null) {
+                    candidates.add(c);
+                }
+            }
 
-		@Override
-		public boolean isIdentified() {
-			return true;
-		}
-		
-		@Override
-		public int value() {
-			return 5 * quantity;
-		}
-	}
+            newPos = candidates.size() > 0 ? Random.element(candidates) : -1;
+        }
+
+        if (newPos != -1) {
+            Bee bee = new Bee();
+            bee.spawn(Dungeon.scalingDepth());
+            bee.setPotInfo(pos, owner);
+            bee.HP = bee.HT;
+            bee.pos = newPos;
+
+            GameScene.add(bee);
+            if (newPos != pos)
+                Actor.addDelayed(new Pushing(bee, pos, newPos), -1f);
+
+            bee.sprite.alpha(0);
+            bee.sprite.parent.add(new AlphaTweener(bee.sprite, 1, 0.15f));
+
+            Sample.INSTANCE.play(Assets.Sounds.BEE);
+            return new ShatteredPot();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    @Override
+    public int value() {
+        return 30 * quantity;
+    }
+
+    // The bee's broken 'home', all this item does is let its bee know where it is,
+    // and who owns it (if anyone).
+    public static class ShatteredPot extends Item {
+
+        {
+            image = ItemSpriteSheet.SHATTPOT;
+            stackable = true;
+        }
+
+        @Override
+        public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+            if (super.doPickUp(hero, pos, isAutoLoot)) {
+                pickupPot(hero);
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public void doDrop(Hero hero) {
+            super.doDrop(hero);
+            dropPot(hero, hero.pos);
+        }
+
+        @Override
+        protected void onThrow(int cell) {
+            super.onThrow(cell);
+            dropPot(curUser, cell);
+        }
+
+        public void pickupPot(Char holder) {
+            for (Bee bee : findBees(holder.pos)) {
+                updateBee(bee, -1, holder);
+            }
+        }
+
+        public void dropPot(Char holder, int dropPos) {
+            for (Bee bee : findBees(holder)) {
+                updateBee(bee, dropPos, null);
+            }
+        }
+
+        public void movePot(int oldpos, int movePos) {
+            for (Bee bee : findBees(oldpos)) {
+                updateBee(bee, movePos, null);
+            }
+        }
+
+        public void destroyPot(int potPos) {
+            for (Bee bee : findBees(potPos)) {
+                updateBee(bee, -1, null);
+            }
+        }
+
+        private void updateBee(Bee bee, int cell, Char holder) {
+            if (bee != null && bee.alignment == Char.Alignment.ENEMY)
+                bee.setPotInfo(cell, holder);
+        }
+
+        // returns up to quantity bees which match the current pot Pos
+        private ArrayList<Bee> findBees(int potPos) {
+            ArrayList<Bee> bees = new ArrayList<>();
+            for (Char c : Actor.chars()) {
+                if (c instanceof Bee && ((Bee) c).potPos() == potPos) {
+                    bees.add((Bee) c);
+                    if (bees.size() >= quantity) {
+                        break;
+                    }
+                }
+            }
+
+            return bees;
+        }
+
+        // returns up to quantity bees which match the current pot holder
+        private ArrayList<Bee> findBees(Char potHolder) {
+            ArrayList<Bee> bees = new ArrayList<>();
+            for (Char c : Actor.chars()) {
+                if (c instanceof Bee && ((Bee) c).potHolderID() == potHolder.id()) {
+                    bees.add((Bee) c);
+                    if (bees.size() >= quantity) {
+                        break;
+                    }
+                }
+            }
+
+            return bees;
+        }
+
+        @Override
+        public boolean isUpgradable() {
+            return false;
+        }
+
+        @Override
+        public boolean isIdentified() {
+            return true;
+        }
+
+        @Override
+        public int value() {
+            return 5 * quantity;
+        }
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -57,614 +57,644 @@ import java.util.Comparator;
 
 public class Item implements Bundlable {
 
-	protected static final String TXT_TO_STRING_LVL		= "%s %+d";
-	protected static final String TXT_TO_STRING_X		= "%s x%d";
-	
-	protected static final float TIME_TO_THROW		= 1.0f;
-	protected static final float TIME_TO_PICK_UP	= 1.0f;
-	protected static final float TIME_TO_DROP		= 1.0f;
-	
-	public static final String AC_DROP		= "DROP";
-	public static final String AC_THROW		= "THROW";
-	
-	protected String defaultAction;
-	public boolean usesTargeting;
+    protected static final String TXT_TO_STRING_LVL = "%s %+d";
+    protected static final String TXT_TO_STRING_X = "%s x%d";
 
-	//TODO should these be private and accessed through methods?
-	public int image = 0;
-	public int icon = -1; //used as an identifier for items with randomized images
-	
-	public boolean stackable = false;
-	protected int quantity = 1;
-	public boolean dropsDownHeap = false;
-	
-	private int level = 0;
+    protected static final float TIME_TO_THROW = 1.0f;
+    protected static final float TIME_TO_PICK_UP = 1.0f;
+    protected static final float TIME_TO_DROP = 1.0f;
 
-	public boolean levelKnown = false;
-	
-	public boolean cursed;
-	public boolean cursedKnown;
-	
-	// Unique items persist through revival
-	public boolean unique = false;
+    public static final String AC_DROP = "DROP";
+    public static final String AC_THROW = "THROW";
 
-	// These items are preserved even if the hero's inventory is lost via unblessed ankh
-	public boolean keptThoughLostInvent = false;
+    protected String defaultAction;
+    public boolean usesTargeting;
 
-	// whether an item can be included in heroes remains
-	public boolean bones = false;
-	
-	public static final Comparator<Item> itemComparator = new Comparator<Item>() {
-		@Override
-		public int compare( Item lhs, Item rhs ) {
-			return Generator.Category.order( lhs ) - Generator.Category.order( rhs );
-		}
-	};
-	
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = new ArrayList<>();
-		actions.add( AC_DROP );
-		actions.add( AC_THROW );
-		return actions;
-	}
+    // TODO should these be private and accessed through methods?
+    public int image = 0;
+    public int icon = -1; // used as an identifier for items with randomized images
 
-	public String actionName(String action, Hero hero){
-		return Messages.get(this, "ac_" + action);
-	}
+    public boolean stackable = false;
+    protected int quantity = 1;
+    public boolean dropsDownHeap = false;
 
-	public final boolean doPickUp( Hero hero ) {
-		return doPickUp( hero, hero.pos );
-	}
+    private int level = 0;
 
-	public boolean doPickUp(Hero hero, int pos) {
-		if (collect( hero.belongings.backpack )) {
-			
-			GameScene.pickUp( this, pos );
-			Sample.INSTANCE.play( Assets.Sounds.ITEM );
-			hero.spendAndNext( TIME_TO_PICK_UP );
-			return true;
-			
-		} else {
-			return false;
-		}
-	}
-	
-	public void doDrop( Hero hero ) {
-		hero.spendAndNext(TIME_TO_DROP);
-		int pos = hero.pos;
-		Dungeon.level.drop(detachAll(hero.belongings.backpack), pos).sprite.drop(pos);
-	}
+    public boolean levelKnown = false;
 
-	//resets an item's properties, to ensure consistency between runs
-	public void reset(){
-		keptThoughLostInvent = false;
-	}
+    public boolean cursed;
+    public boolean cursedKnown;
 
-	public void doThrow( Hero hero ) {
-		GameScene.selectCell(thrower);
-	}
-	
-	public void execute( Hero hero, String action ) {
+    // Unique items persist through revival
+    public boolean unique = false;
 
-		GameScene.cancel();
-		curUser = hero;
-		curItem = this;
-		
-		if (action.equals( AC_DROP )) {
-			
-			if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
-				doDrop(hero);
-			}
-			
-		} else if (action.equals( AC_THROW )) {
-			
-			if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
-				doThrow(hero);
-			}
-			
-		}
-	}
+    // These items are preserved even if the hero's inventory is lost via unblessed
+    // ankh
+    public boolean keptThoughLostInvent = false;
 
-	//can be overridden if default action is variable
-	public String defaultAction(){
-		return defaultAction;
-	}
-	
-	public void execute( Hero hero ) {
-		String action = defaultAction();
-		if (action != null) {
-			execute(hero, defaultAction());
-		}
-	}
-	
-	protected void onThrow( int cell ) {
-		Heap heap = Dungeon.level.drop( this, cell );
-		if (!heap.isEmpty()) {
-			heap.sprite.drop( cell );
-		}
-	}
-	
-	//takes two items and merges them (if possible)
-	public Item merge( Item other ){
-		if (isSimilar( other )){
-			quantity += other.quantity;
-			other.quantity = 0;
-		}
-		return this;
-	}
-	
-	public boolean collect( Bag container ) {
+    // whether an item can be included in heroes remains
+    public boolean bones = false;
 
-		if (quantity <= 0){
-			return true;
-		}
+    public static final Comparator<Item> itemComparator = new Comparator<Item>() {
+        @Override
+        public int compare(Item lhs, Item rhs) {
+            return Generator.Category.order(lhs) - Generator.Category.order(rhs);
+        }
+    };
 
-		ArrayList<Item> items = container.items;
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = new ArrayList<>();
+        actions.add(AC_DROP);
+        actions.add(AC_THROW);
+        return actions;
+    }
 
-		if (items.contains( this )) {
-			return true;
-		}
+    public String actionName(String action, Hero hero) {
+        return Messages.get(this, "ac_" + action);
+    }
 
-		for (Item item:items) {
-			if (item instanceof Bag && ((Bag)item).canHold( this )) {
-				if (collect( (Bag)item )){
-					return true;
-				}
-			}
-		}
+    public boolean doPickUp(Hero hero) {
+        return doPickUp(hero, hero.pos);
+    }
 
-		if (!container.canHold(this)){
-			return false;
-		}
-		
-		if (stackable) {
-			for (Item item:items) {
-				if (isSimilar( item )) {
-					item.merge( this );
-					item.updateQuickslot();
-					if (Dungeon.hero != null && Dungeon.hero.isAlive()) {
-						Badges.validateItemLevelAquired( this );
-						Talent.onItemCollected(Dungeon.hero, item);
-						if (isIdentified()) Catalog.setSeen(getClass());
-					}
-					if (TippedDart.lostDarts > 0){
-						Dart d = new Dart();
-						d.quantity(TippedDart.lostDarts);
-						TippedDart.lostDarts = 0;
-						if (!d.collect()){
-							//have to handle this in an actor as we can't manipulate the heap during pickup
-							Actor.add(new Actor() {
-								{ actPriority = VFX_PRIO; }
-								@Override
-								protected boolean act() {
-									Dungeon.level.drop(d, Dungeon.hero.pos).sprite.drop();
-									Actor.remove(this);
-									return true;
-								}
-							});
-						}
-					}
-					return true;
-				}
-			}
-		}
+    public boolean doPickUp(Hero hero, boolean isAutoLoot) {
+        return doPickUp(hero, hero.pos, isAutoLoot);
+    }
 
-		if (Dungeon.hero != null && Dungeon.hero.isAlive()) {
-			Badges.validateItemLevelAquired( this );
-			Talent.onItemCollected( Dungeon.hero, this );
-			if (isIdentified()) Catalog.setSeen(getClass());
-		}
+    public boolean doPickUp(Hero hero, int pos) {
+        return doPickUp(hero, hero.pos, false);
+    }
 
-		items.add( this );
-		Dungeon.quickslot.replacePlaceholder(this);
-		Collections.sort( items, itemComparator );
-		updateQuickslot();
-		return true;
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (collect(hero.belongings.backpack)) {
+            GameScene.pickUp(this, pos);
+            Sample.INSTANCE.play(Assets.Sounds.ITEM);
+            if (!isAutoLoot)
+                hero.spendAndNext(TIME_TO_PICK_UP);
+            return true;
+        } else {
+            return false;
+        }
+    }
 
-	}
-	
-	public boolean collect() {
-		return collect( Dungeon.hero.belongings.backpack );
-	}
-	
-	//returns a new item if the split was sucessful and there are now 2 items, otherwise null
-	public Item split( int amount ){
-		if (amount <= 0 || amount >= quantity()) {
-			return null;
-		} else {
-			//pssh, who needs copy constructors?
-			Item split = Reflection.newInstance(getClass());
-			
-			if (split == null){
-				return null;
-			}
-			
-			Bundle copy = new Bundle();
-			this.storeInBundle(copy);
-			split.restoreFromBundle(copy);
-			split.quantity(amount);
-			quantity -= amount;
-			
-			return split;
-		}
-	}
-	
-	public final Item detach( Bag container ) {
-		
-		if (quantity <= 0) {
-			
-			return null;
-			
-		} else
-		if (quantity == 1) {
+    public void doDrop(Hero hero) {
+        hero.spendAndNext(TIME_TO_DROP);
+        int pos = hero.pos;
+        Dungeon.level.drop(detachAll(hero.belongings.backpack), pos).sprite.drop(pos);
+    }
 
-			if (stackable){
-				Dungeon.quickslot.convertToPlaceholder(this);
-			}
+    // resets an item's properties, to ensure consistency between runs
+    public void reset() {
+        keptThoughLostInvent = false;
+    }
 
-			return detachAll( container );
-			
-		} else {
-			
-			
-			Item detached = split(1);
-			updateQuickslot();
-			if (detached != null) detached.onDetach( );
-			return detached;
-			
-		}
-	}
-	
-	public final Item detachAll( Bag container ) {
-		Dungeon.quickslot.clearItem( this );
+    public void doThrow(Hero hero) {
+        GameScene.selectCell(thrower);
+    }
 
-		for (Item item : container.items) {
-			if (item == this) {
-				container.items.remove(this);
-				item.onDetach();
-				container.grabItems(); //try to put more items into the bag as it now has free space
-				updateQuickslot();
-				return this;
-			} else if (item instanceof Bag) {
-				Bag bag = (Bag)item;
-				if (bag.contains( this )) {
-					return detachAll( bag );
-				}
-			}
-		}
+    public void execute(Hero hero, String action) {
 
-		updateQuickslot();
-		return this;
-	}
-	
-	public boolean isSimilar( Item item ) {
-		return level == item.level && getClass() == item.getClass();
-	}
+        GameScene.cancel();
+        curUser = hero;
+        curItem = this;
 
-	protected void onDetach(){}
+        if (action.equals(AC_DROP)) {
 
-	//returns the true level of the item, ignoring all modifiers aside from upgrades
-	public final int trueLevel(){
-		return level;
-	}
+            if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
+                doDrop(hero);
+            }
 
-	//returns the persistant level of the item, only affected by modifiers which are persistent (e.g. curse infusion)
-	public int level(){
-		return level;
-	}
-	
-	//returns the level of the item, after it may have been modified by temporary boosts/reductions
-	//note that not all item properties should care about buffs/debuffs! (e.g. str requirement)
-	public int buffedLvl(){
-		//only the hero can be affected by Degradation
-		if (Dungeon.hero.buff( Degrade.class ) != null
-			&& (isEquipped( Dungeon.hero ) || Dungeon.hero.belongings.contains( this ))) {
-			return Degrade.reduceLevel(level());
-		} else {
-			return level();
-		}
-	}
+        } else if (action.equals(AC_THROW)) {
 
-	public void level( int value ){
-		level = value;
+            if (hero.belongings.backpack.contains(this) || isEquipped(hero)) {
+                doThrow(hero);
+            }
 
-		updateQuickslot();
-	}
-	
-	public Item upgrade() {
-		
-		this.level++;
+        }
+    }
 
-		updateQuickslot();
-		
-		return this;
-	}
-	
-	final public Item upgrade( int n ) {
-		for (int i=0; i < n; i++) {
-			upgrade();
-		}
-		
-		return this;
-	}
-	
-	public Item degrade() {
-		
-		this.level--;
-		
-		return this;
-	}
-	
-	final public Item degrade( int n ) {
-		for (int i=0; i < n; i++) {
-			degrade();
-		}
-		
-		return this;
-	}
-	
-	public int visiblyUpgraded() {
-		return levelKnown ? level() : 0;
-	}
+    // can be overridden if default action is variable
+    public String defaultAction() {
+        return defaultAction;
+    }
 
-	public int buffedVisiblyUpgraded() {
-		return levelKnown ? buffedLvl() : 0;
-	}
-	
-	public boolean visiblyCursed() {
-		return cursed && cursedKnown;
-	}
-	
-	public boolean isUpgradable() {
-		return true;
-	}
-	
-	public boolean isIdentified() {
-		return levelKnown && cursedKnown;
-	}
-	
-	public boolean isEquipped( Hero hero ) {
-		return false;
-	}
+    public void execute(Hero hero) {
+        String action = defaultAction();
+        if (action != null) {
+            execute(hero, defaultAction());
+        }
+    }
 
-	public final Item identify(){
-		return identify(true);
-	}
+    protected void onThrow(int cell) {
+        Heap heap = Dungeon.level.drop(this, cell);
+        if (!heap.isEmpty()) {
+            heap.sprite.drop(cell);
+        }
+    }
 
-	public Item identify( boolean byHero ) {
+    // takes two items and merges them (if possible)
+    public Item merge(Item other) {
+        if (isSimilar(other)) {
+            quantity += other.quantity;
+            other.quantity = 0;
+        }
+        return this;
+    }
 
-		if (byHero && Dungeon.hero != null && Dungeon.hero.isAlive()){
-			Catalog.setSeen(getClass());
-			if (!isIdentified()) Talent.onItemIdentified(Dungeon.hero, this);
-		}
+    /**
+     * Returns true if the item can be collected by the given container.
+     * Also performs some actions related to picking up the item.
+     * This is the case when
+     * - the container doesn't hold any items yet or
+     * - the item is stackable or
+     * - the container already contains the item.
+     */
+    public boolean collect(Bag container) {
+        if (quantity <= 0) {
+            return true;
+        }
 
-		levelKnown = true;
-		cursedKnown = true;
-		Item.updateQuickslot();
-		
-		return this;
-	}
-	
-	public void onHeroGainExp( float levelPercent, Hero hero ){
-		//do nothing by default
-	}
-	
-	public static void evoke( Hero hero ) {
-		hero.sprite.emitter().burst( Speck.factory( Speck.EVOKE ), 5 );
-	}
+        ArrayList<Item> items = container.items;
 
-	public String title() {
+        if (items.contains(this)) {
+            return true;
+        }
 
-		String name = name();
+        for (Item item : items) {
+            if (item instanceof Bag && ((Bag) item).canHold(this)) {
+                if (collect((Bag) item)) {
+                    return true;
+                }
+            }
+        }
 
-		if (visiblyUpgraded() != 0)
-			name = Messages.format( TXT_TO_STRING_LVL, name, visiblyUpgraded()  );
+        if (!container.canHold(this)) {
+            return false;
+        }
 
-		if (quantity > 1)
-			name = Messages.format( TXT_TO_STRING_X, name, quantity );
+        if (stackable) {
+            for (Item item : items) {
+                if (isSimilar(item)) {
+                    item.merge(this);
+                    item.updateQuickslot();
+                    if (Dungeon.hero != null && Dungeon.hero.isAlive()) {
+                        Badges.validateItemLevelAquired(this);
+                        Talent.onItemCollected(Dungeon.hero, item);
+                        if (isIdentified())
+                            Catalog.setSeen(getClass());
+                    }
+                    if (TippedDart.lostDarts > 0) {
+                        Dart d = new Dart();
+                        d.quantity(TippedDart.lostDarts);
+                        TippedDart.lostDarts = 0;
+                        if (!d.collect()) {
+                            // have to handle this in an actor as we can't manipulate the heap during pickup
+                            Actor.add(new Actor() {
+                                {
+                                    actPriority = VFX_PRIO;
+                                }
 
-		return name;
+                                @Override
+                                protected boolean act() {
+                                    Dungeon.level.drop(d, Dungeon.hero.pos).sprite.drop();
+                                    Actor.remove(this);
+                                    return true;
+                                }
+                            });
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
 
-	}
-	
-	public String name() {
-		return trueName();
-	}
-	
-	public final String trueName() {
-		return Messages.get(this, "name");
-	}
-	
-	public int image() {
-		return image;
-	}
-	
-	public ItemSprite.Glowing glowing() {
-		return null;
-	}
+        if (Dungeon.hero != null && Dungeon.hero.isAlive()) {
+            Badges.validateItemLevelAquired(this);
+            Talent.onItemCollected(Dungeon.hero, this);
+            if (isIdentified())
+                Catalog.setSeen(getClass());
+        }
 
-	public Emitter emitter() { return null; }
-	
-	public String info() {
-		return desc();
-	}
-	
-	public String desc() {
-		return Messages.get(this, "desc");
-	}
-	
-	public int quantity() {
-		return quantity;
-	}
-	
-	public Item quantity( int value ) {
-		quantity = value;
-		return this;
-	}
+        items.add(this);
+        Dungeon.quickslot.replacePlaceholder(this);
+        Collections.sort(items, itemComparator);
+        updateQuickslot();
+        return true;
+    }
 
-	//item's value in gold coins
-	public int value() {
-		return 0;
-	}
+    public boolean collect() {
+        return collect(Dungeon.hero.belongings.backpack);
+    }
 
-	//item's value in energy crystals
-	public int energyVal() {
-		return 0;
-	}
-	
-	public Item virtual(){
-		Item item = Reflection.newInstance(getClass());
-		if (item == null) return null;
-		
-		item.quantity = 0;
-		item.level = level;
-		return item;
-	}
-	
-	public Item random() {
-		return this;
-	}
-	
-	public String status() {
-		return quantity != 1 ? Integer.toString( quantity ) : null;
-	}
+    // returns a new item if the split was sucessful and there are now 2 items,
+    // otherwise null
+    public Item split(int amount) {
+        if (amount <= 0 || amount >= quantity()) {
+            return null;
+        } else {
+            // pssh, who needs copy constructors?
+            Item split = Reflection.newInstance(getClass());
 
-	public static void updateQuickslot() {
-		GameScene.updateItemDisplays = true;
-	}
-	
-	private static final String QUANTITY		= "quantity";
-	private static final String LEVEL			= "level";
-	private static final String LEVEL_KNOWN		= "levelKnown";
-	private static final String CURSED			= "cursed";
-	private static final String CURSED_KNOWN	= "cursedKnown";
-	private static final String QUICKSLOT		= "quickslotpos";
-	private static final String KEPT_LOST       = "kept_lost";
-	
-	@Override
-	public void storeInBundle( Bundle bundle ) {
-		bundle.put( QUANTITY, quantity );
-		bundle.put( LEVEL, level );
-		bundle.put( LEVEL_KNOWN, levelKnown );
-		bundle.put( CURSED, cursed );
-		bundle.put( CURSED_KNOWN, cursedKnown );
-		if (Dungeon.quickslot.contains(this)) {
-			bundle.put( QUICKSLOT, Dungeon.quickslot.getSlot(this) );
-		}
-		bundle.put( KEPT_LOST, keptThoughLostInvent );
-	}
-	
-	@Override
-	public void restoreFromBundle( Bundle bundle ) {
-		quantity	= bundle.getInt( QUANTITY );
-		levelKnown	= bundle.getBoolean( LEVEL_KNOWN );
-		cursedKnown	= bundle.getBoolean( CURSED_KNOWN );
-		
-		int level = bundle.getInt( LEVEL );
-		if (level > 0) {
-			upgrade( level );
-		} else if (level < 0) {
-			degrade( -level );
-		}
-		
-		cursed	= bundle.getBoolean( CURSED );
+            if (split == null) {
+                return null;
+            }
 
-		//only want to populate slot on first load.
-		if (Dungeon.hero == null) {
-			if (bundle.contains(QUICKSLOT)) {
-				Dungeon.quickslot.setSlot(bundle.getInt(QUICKSLOT), this);
-			}
-		}
+            Bundle copy = new Bundle();
+            this.storeInBundle(copy);
+            split.restoreFromBundle(copy);
+            split.quantity(amount);
+            quantity -= amount;
 
-		keptThoughLostInvent = bundle.getBoolean( KEPT_LOST );
-	}
+            return split;
+        }
+    }
 
-	public int targetingPos( Hero user, int dst ){
-		return throwPos( user, dst );
-	}
+    public final Item detach(Bag container) {
 
-	public int throwPos( Hero user, int dst){
-		return new Ballistica( user.pos, dst, Ballistica.PROJECTILE ).collisionPos;
-	}
+        if (quantity <= 0) {
 
-	public void throwSound(){
-		Sample.INSTANCE.play(Assets.Sounds.MISS, 0.6f, 0.6f, 1.5f);
-	}
-	
-	public void cast( final Hero user, final int dst ) {
-		
-		final int cell = throwPos( user, dst );
-		user.sprite.zap( cell );
-		user.busy();
+            return null;
 
-		throwSound();
+        } else if (quantity == 1) {
 
-		Char enemy = Actor.findChar( cell );
-		QuickSlotButton.target(enemy);
-		
-		final float delay = castDelay(user, dst);
+            if (stackable) {
+                Dungeon.quickslot.convertToPlaceholder(this);
+            }
 
-		if (enemy != null) {
-			((MissileSprite) user.sprite.parent.recycle(MissileSprite.class)).
-					reset(user.sprite,
-							enemy.sprite,
-							this,
-							new Callback() {
-						@Override
-						public void call() {
-							curUser = user;
-							Item i = Item.this.detach(user.belongings.backpack);
-							if (i != null) i.onThrow(cell);
-							if (curUser.hasTalent(Talent.IMPROVISED_PROJECTILES)
-									&& !(Item.this instanceof MissileWeapon)
-									&& curUser.buff(Talent.ImprovisedProjectileCooldown.class) == null){
-								if (enemy != null && enemy.alignment != curUser.alignment){
-									Sample.INSTANCE.play(Assets.Sounds.HIT);
-									Buff.affect(enemy, Blindness.class, 1f + curUser.pointsInTalent(Talent.IMPROVISED_PROJECTILES));
-									Buff.affect(curUser, Talent.ImprovisedProjectileCooldown.class, 50f);
-								}
-							}
-							if (user.buff(Talent.LethalMomentumTracker.class) != null){
-								user.buff(Talent.LethalMomentumTracker.class).detach();
-								user.next();
-							} else {
-								user.spendAndNext(delay);
-							}
-						}
-					});
-		} else {
-			((MissileSprite) user.sprite.parent.recycle(MissileSprite.class)).
-					reset(user.sprite,
-							cell,
-							this,
-							new Callback() {
-						@Override
-						public void call() {
-							curUser = user;
-							Item i = Item.this.detach(user.belongings.backpack);
-							if (i != null) i.onThrow(cell);
-							user.spendAndNext(delay);
-						}
-					});
-		}
-	}
-	
-	public float castDelay( Char user, int dst ){
-		return TIME_TO_THROW;
-	}
-	
-	protected static Hero curUser = null;
-	protected static Item curItem = null;
-	protected static CellSelector.Listener thrower = new CellSelector.Listener() {
-		@Override
-		public void onSelect( Integer target ) {
-			if (target != null) {
-				curItem.cast( curUser, target );
-			}
-		}
-		@Override
-		public String prompt() {
-			return Messages.get(Item.class, "prompt");
-		}
-	};
+            return detachAll(container);
+
+        } else {
+
+            Item detached = split(1);
+            updateQuickslot();
+            if (detached != null)
+                detached.onDetach();
+            return detached;
+
+        }
+    }
+
+    public final Item detachAll(Bag container) {
+        Dungeon.quickslot.clearItem(this);
+
+        for (Item item : container.items) {
+            if (item == this) {
+                container.items.remove(this);
+                item.onDetach();
+                container.grabItems(); // try to put more items into the bag as it now has free space
+                updateQuickslot();
+                return this;
+            } else if (item instanceof Bag) {
+                Bag bag = (Bag) item;
+                if (bag.contains(this)) {
+                    return detachAll(bag);
+                }
+            }
+        }
+
+        updateQuickslot();
+        return this;
+    }
+
+    public boolean isSimilar(Item item) {
+        return level == item.level && getClass() == item.getClass();
+    }
+
+    protected void onDetach() {
+    }
+
+    // returns the true level of the item, ignoring all modifiers aside from
+    // upgrades
+    public final int trueLevel() {
+        return level;
+    }
+
+    // returns the persistant level of the item, only affected by modifiers which
+    // are persistent (e.g. curse infusion)
+    public int level() {
+        return level;
+    }
+
+    // returns the level of the item, after it may have been modified by temporary
+    // boosts/reductions
+    // note that not all item properties should care about buffs/debuffs! (e.g. str
+    // requirement)
+    public int buffedLvl() {
+        // only the hero can be affected by Degradation
+        if (Dungeon.hero.buff(Degrade.class) != null
+                && (isEquipped(Dungeon.hero) || Dungeon.hero.belongings.contains(this))) {
+            return Degrade.reduceLevel(level());
+        } else {
+            return level();
+        }
+    }
+
+    public void level(int value) {
+        level = value;
+
+        updateQuickslot();
+    }
+
+    public Item upgrade() {
+
+        this.level++;
+
+        updateQuickslot();
+
+        return this;
+    }
+
+    final public Item upgrade(int n) {
+        for (int i = 0; i < n; i++) {
+            upgrade();
+        }
+
+        return this;
+    }
+
+    public Item degrade() {
+
+        this.level--;
+
+        return this;
+    }
+
+    final public Item degrade(int n) {
+        for (int i = 0; i < n; i++) {
+            degrade();
+        }
+
+        return this;
+    }
+
+    public int visiblyUpgraded() {
+        return levelKnown ? level() : 0;
+    }
+
+    public int buffedVisiblyUpgraded() {
+        return levelKnown ? buffedLvl() : 0;
+    }
+
+    public boolean visiblyCursed() {
+        return cursed && cursedKnown;
+    }
+
+    public boolean isUpgradable() {
+        return true;
+    }
+
+    public boolean isIdentified() {
+        return levelKnown && cursedKnown;
+    }
+
+    public boolean isEquipped(Hero hero) {
+        return false;
+    }
+
+    public final Item identify() {
+        return identify(true);
+    }
+
+    public Item identify(boolean byHero) {
+
+        if (byHero && Dungeon.hero != null && Dungeon.hero.isAlive()) {
+            Catalog.setSeen(getClass());
+            if (!isIdentified())
+                Talent.onItemIdentified(Dungeon.hero, this);
+        }
+
+        levelKnown = true;
+        cursedKnown = true;
+        Item.updateQuickslot();
+
+        return this;
+    }
+
+    public void onHeroGainExp(float levelPercent, Hero hero) {
+        // do nothing by default
+    }
+
+    public static void evoke(Hero hero) {
+        hero.sprite.emitter().burst(Speck.factory(Speck.EVOKE), 5);
+    }
+
+    public String title() {
+
+        String name = name();
+
+        if (visiblyUpgraded() != 0)
+            name = Messages.format(TXT_TO_STRING_LVL, name, visiblyUpgraded());
+
+        if (quantity > 1)
+            name = Messages.format(TXT_TO_STRING_X, name, quantity);
+
+        return name;
+
+    }
+
+    public String name() {
+        return trueName();
+    }
+
+    public final String trueName() {
+        return Messages.get(this, "name");
+    }
+
+    public int image() {
+        return image;
+    }
+
+    public ItemSprite.Glowing glowing() {
+        return null;
+    }
+
+    public Emitter emitter() {
+        return null;
+    }
+
+    public String info() {
+        return desc();
+    }
+
+    public String desc() {
+        return Messages.get(this, "desc");
+    }
+
+    public int quantity() {
+        return quantity;
+    }
+
+    public Item quantity(int value) {
+        quantity = value;
+        return this;
+    }
+
+    // item's value in gold coins
+    public int value() {
+        return 0;
+    }
+
+    // item's value in energy crystals
+    public int energyVal() {
+        return 0;
+    }
+
+    public Item virtual() {
+        Item item = Reflection.newInstance(getClass());
+        if (item == null)
+            return null;
+
+        item.quantity = 0;
+        item.level = level;
+        return item;
+    }
+
+    public Item random() {
+        return this;
+    }
+
+    public String status() {
+        return quantity != 1 ? Integer.toString(quantity) : null;
+    }
+
+    public static void updateQuickslot() {
+        GameScene.updateItemDisplays = true;
+    }
+
+    private static final String QUANTITY = "quantity";
+    private static final String LEVEL = "level";
+    private static final String LEVEL_KNOWN = "levelKnown";
+    private static final String CURSED = "cursed";
+    private static final String CURSED_KNOWN = "cursedKnown";
+    private static final String QUICKSLOT = "quickslotpos";
+    private static final String KEPT_LOST = "kept_lost";
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        bundle.put(QUANTITY, quantity);
+        bundle.put(LEVEL, level);
+        bundle.put(LEVEL_KNOWN, levelKnown);
+        bundle.put(CURSED, cursed);
+        bundle.put(CURSED_KNOWN, cursedKnown);
+        if (Dungeon.quickslot.contains(this)) {
+            bundle.put(QUICKSLOT, Dungeon.quickslot.getSlot(this));
+        }
+        bundle.put(KEPT_LOST, keptThoughLostInvent);
+    }
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        quantity = bundle.getInt(QUANTITY);
+        levelKnown = bundle.getBoolean(LEVEL_KNOWN);
+        cursedKnown = bundle.getBoolean(CURSED_KNOWN);
+
+        int level = bundle.getInt(LEVEL);
+        if (level > 0) {
+            upgrade(level);
+        } else if (level < 0) {
+            degrade(-level);
+        }
+
+        cursed = bundle.getBoolean(CURSED);
+
+        // only want to populate slot on first load.
+        if (Dungeon.hero == null) {
+            if (bundle.contains(QUICKSLOT)) {
+                Dungeon.quickslot.setSlot(bundle.getInt(QUICKSLOT), this);
+            }
+        }
+
+        keptThoughLostInvent = bundle.getBoolean(KEPT_LOST);
+    }
+
+    public int targetingPos(Hero user, int dst) {
+        return throwPos(user, dst);
+    }
+
+    public int throwPos(Hero user, int dst) {
+        return new Ballistica(user.pos, dst, Ballistica.PROJECTILE).collisionPos;
+    }
+
+    public void throwSound() {
+        Sample.INSTANCE.play(Assets.Sounds.MISS, 0.6f, 0.6f, 1.5f);
+    }
+
+    public void cast(final Hero user, final int dst) {
+
+        final int cell = throwPos(user, dst);
+        user.sprite.zap(cell);
+        user.busy();
+
+        throwSound();
+
+        Char enemy = Actor.findChar(cell);
+        QuickSlotButton.target(enemy);
+
+        final float delay = castDelay(user, dst);
+
+        if (enemy != null) {
+            ((MissileSprite) user.sprite.parent.recycle(MissileSprite.class)).reset(user.sprite,
+                    enemy.sprite,
+                    this,
+                    new Callback() {
+                        @Override
+                        public void call() {
+                            curUser = user;
+                            Item i = Item.this.detach(user.belongings.backpack);
+                            if (i != null)
+                                i.onThrow(cell);
+                            if (curUser.hasTalent(Talent.IMPROVISED_PROJECTILES)
+                                    && !(Item.this instanceof MissileWeapon)
+                                    && curUser.buff(Talent.ImprovisedProjectileCooldown.class) == null) {
+                                if (enemy != null && enemy.alignment != curUser.alignment) {
+                                    Sample.INSTANCE.play(Assets.Sounds.HIT);
+                                    Buff.affect(enemy, Blindness.class,
+                                            1f + curUser.pointsInTalent(Talent.IMPROVISED_PROJECTILES));
+                                    Buff.affect(curUser, Talent.ImprovisedProjectileCooldown.class, 50f);
+                                }
+                            }
+                            if (user.buff(Talent.LethalMomentumTracker.class) != null) {
+                                user.buff(Talent.LethalMomentumTracker.class).detach();
+                                user.next();
+                            } else {
+                                user.spendAndNext(delay);
+                            }
+                        }
+                    });
+        } else {
+            ((MissileSprite) user.sprite.parent.recycle(MissileSprite.class)).reset(user.sprite,
+                    cell,
+                    this,
+                    new Callback() {
+                        @Override
+                        public void call() {
+                            curUser = user;
+                            Item i = Item.this.detach(user.belongings.backpack);
+                            if (i != null)
+                                i.onThrow(cell);
+                            user.spendAndNext(delay);
+                        }
+                    });
+        }
+    }
+
+    public float castDelay(Char user, int dst) {
+        return TIME_TO_THROW;
+    }
+
+    protected static Hero curUser = null;
+    protected static Item curItem = null;
+    protected static CellSelector.Listener thrower = new CellSelector.Listener() {
+        @Override
+        public void onSelect(Integer target) {
+            if (target != null) {
+                curItem.cast(curUser, target);
+            }
+        }
+
+        @Override
+        public String prompt() {
+            return Messages.get(Item.class, "prompt");
+        }
+    };
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -114,7 +114,7 @@ public class Item implements Bundlable {
     }
 
     public boolean doPickUp(Hero hero) {
-        return doPickUp(hero, hero.pos);
+        return doPickUp(hero, hero.pos, false);
     }
 
     public boolean doPickUp(Hero hero, boolean isAutoLoot) {
@@ -125,6 +125,8 @@ public class Item implements Bundlable {
         return doPickUp(hero, hero.pos, false);
     }
 
+    // You have to overwrite this one in all kinds of subclasses for implementing
+    // auto-looting
     public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
         if (collect(hero.belongings.backpack)) {
             GameScene.pickUp(this, pos);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/LostBackpack.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/LostBackpack.java
@@ -36,46 +36,47 @@ import com.watabou.noosa.audio.Sample;
 
 public class LostBackpack extends Item {
 
-	{
-		image = ItemSpriteSheet.BACKPACK;
+    {
+        image = ItemSpriteSheet.BACKPACK;
 
-		unique = true;
-	}
+        unique = true;
+    }
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (hero.buff(LostInventory.class) != null){
-			hero.buff(LostInventory.class).detach();
-		}
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (hero.buff(LostInventory.class) != null) {
+            hero.buff(LostInventory.class).detach();
+        }
 
-		MagicalHolster holster = hero.belongings.getItem(MagicalHolster.class);
-		for (Item i : hero.belongings){
-			if (i.keptThoughLostInvent){
-				i.keptThoughLostInvent = false; //don't reactivate, was previously activated
-			} else {
-				if (i instanceof EquipableItem && i.isEquipped(hero)){
-					((EquipableItem) i).activate(hero);
-				} else if ( i instanceof CloakOfShadows && hero.hasTalent(Talent.LIGHT_CLOAK)){
-					((CloakOfShadows) i).activate(hero);
-				} else if (i instanceof Wand){
-					if (holster != null && holster.contains(i)){
-						((Wand) i).charge(hero, MagicalHolster.HOLSTER_SCALE_FACTOR);
-					} else {
-						((Wand) i).charge(hero);
-					}
-				} else if (i instanceof MagesStaff){
-					((MagesStaff) i).applyWandChargeBuff(hero);
-				}
-			}
-		}
+        MagicalHolster holster = hero.belongings.getItem(MagicalHolster.class);
+        for (Item i : hero.belongings) {
+            if (i.keptThoughLostInvent) {
+                i.keptThoughLostInvent = false; // don't reactivate, was previously activated
+            } else {
+                if (i instanceof EquipableItem && i.isEquipped(hero)) {
+                    ((EquipableItem) i).activate(hero);
+                } else if (i instanceof CloakOfShadows && hero.hasTalent(Talent.LIGHT_CLOAK)) {
+                    ((CloakOfShadows) i).activate(hero);
+                } else if (i instanceof Wand) {
+                    if (holster != null && holster.contains(i)) {
+                        ((Wand) i).charge(hero, MagicalHolster.HOLSTER_SCALE_FACTOR);
+                    } else {
+                        ((Wand) i).charge(hero);
+                    }
+                } else if (i instanceof MagesStaff) {
+                    ((MagesStaff) i).applyWandChargeBuff(hero);
+                }
+            }
+        }
 
-		hero.updateHT(false);
+        hero.updateHT(false);
 
-		Item.updateQuickslot();
-		Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-		hero.spendAndNext(TIME_TO_PICK_UP);
-		GameScene.pickUp( this, pos );
-		((HeroSprite)hero.sprite).updateArmor();
-		return true;
-	}
+        Item.updateQuickslot();
+        Sample.INSTANCE.play(Assets.Sounds.DEWDROP);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
+        GameScene.pickUp(this, pos);
+        ((HeroSprite) hero.sprite).updateArmor();
+        return true;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/TengusMask.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/TengusMask.java
@@ -41,76 +41,76 @@ import com.watabou.noosa.particles.Emitter;
 import java.util.ArrayList;
 
 public class TengusMask extends Item {
-	
-	private static final String AC_WEAR	= "WEAR";
-	
-	{
-		stackable = false;
-		image = ItemSpriteSheet.MASK;
 
-		defaultAction = AC_WEAR;
+    private static final String AC_WEAR = "WEAR";
 
-		unique = true;
-	}
-	
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		actions.add( AC_WEAR );
-		return actions;
-	}
-	
-	@Override
-	public void execute( Hero hero, String action ) {
+    {
+        stackable = false;
+        image = ItemSpriteSheet.MASK;
 
-		super.execute( hero, action );
+        defaultAction = AC_WEAR;
 
-		if (action.equals( AC_WEAR )) {
-			
-			curUser = hero;
+        unique = true;
+    }
 
-			GameScene.show( new WndChooseSubclass( this, hero ) );
-			
-		}
-	}
-	
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		Badges.validateMastery();
-		return super.doPickUp( hero, pos );
-	}
-	
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	public void choose( HeroSubClass way ) {
-		
-		detach( curUser.belongings.backpack );
-		
-		curUser.spend( Actor.TICK );
-		curUser.busy();
-		
-		curUser.subClass = way;
-		Talent.initSubclassTalents(curUser);
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        actions.add(AC_WEAR);
+        return actions;
+    }
 
-		if (way == HeroSubClass.ASSASSIN && curUser.invisible > 0){
-			Buff.affect(curUser, Preparation.class);
-		}
-		
-		curUser.sprite.operate( curUser.pos );
-		Sample.INSTANCE.play( Assets.Sounds.MASTERY );
-		
-		Emitter e = curUser.sprite.centerEmitter();
-		e.pos(e.x-2, e.y-6, 4, 4);
-		e.start(Speck.factory(Speck.MASK), 0.05f, 20);
-		GLog.p( Messages.get(this, "used"));
-		
-	}
+    @Override
+    public void execute(Hero hero, String action) {
+
+        super.execute(hero, action);
+
+        if (action.equals(AC_WEAR)) {
+
+            curUser = hero;
+
+            GameScene.show(new WndChooseSubclass(this, hero));
+
+        }
+    }
+
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        Badges.validateMastery();
+        return super.doPickUp(hero, pos, isAutoLoot);
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    public void choose(HeroSubClass way) {
+
+        detach(curUser.belongings.backpack);
+
+        curUser.spend(Actor.TICK);
+        curUser.busy();
+
+        curUser.subClass = way;
+        Talent.initSubclassTalents(curUser);
+
+        if (way == HeroSubClass.ASSASSIN && curUser.invisible > 0) {
+            Buff.affect(curUser, Preparation.class);
+        }
+
+        curUser.sprite.operate(curUser.pos);
+        Sample.INSTANCE.play(Assets.Sounds.MASTERY);
+
+        Emitter e = curUser.sprite.centerEmitter();
+        e.pos(e.x - 2, e.y - 6, 4, 4);
+        e.start(Speck.factory(Speck.MASK), 0.05f, 20);
+        GLog.p(Messages.get(this, "used"));
+
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/DriedRose.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/DriedRose.java
@@ -81,938 +81,958 @@ import java.util.ArrayList;
 
 public class DriedRose extends Artifact {
 
-	{
-		image = ItemSpriteSheet.ARTIFACT_ROSE1;
-
-		levelCap = 10;
-
-		charge = 100;
-		chargeCap = 100;
-
-		defaultAction = AC_SUMMON;
-	}
-
-	private boolean talkedTo = false;
-	private boolean firstSummon = false;
-	
-	private GhostHero ghost = null;
-	private int ghostID = 0;
-	
-	private MeleeWeapon weapon = null;
-	private Armor armor = null;
-
-	public int droppedPetals = 0;
-
-	public static final String AC_SUMMON = "SUMMON";
-	public static final String AC_DIRECT = "DIRECT";
-	public static final String AC_OUTFIT = "OUTFIT";
-
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		if (!Ghost.Quest.completed()){
-			return actions;
-		}
-		if (isEquipped( hero )
-				&& charge == chargeCap
-				&& !cursed
-				&& hero.buff(MagicImmune.class) == null
-				&& ghostID == 0) {
-			actions.add(AC_SUMMON);
-		}
-		if (ghostID != 0){
-			actions.add(AC_DIRECT);
-		}
-		if (isIdentified() && !cursed){
-			actions.add(AC_OUTFIT);
-		}
-		
-		return actions;
-	}
-
-	@Override
-	public String defaultAction() {
-		if (ghost != null){
-			return AC_DIRECT;
-		} else {
-			return AC_SUMMON;
-		}
-	}
-
-	@Override
-	public void execute( Hero hero, String action ) {
-
-		super.execute(hero, action);
-
-		if (action.equals(AC_SUMMON)) {
-
-			if (hero.buff(MagicImmune.class) != null) return;
-
-			if (!Ghost.Quest.completed())   GameScene.show(new WndUseItem(null, this));
-			else if (ghost != null)         GLog.i( Messages.get(this, "spawned") );
-			else if (!isEquipped( hero ))   GLog.i( Messages.get(Artifact.class, "need_to_equip") );
-			else if (charge != chargeCap)   GLog.i( Messages.get(this, "no_charge") );
-			else if (cursed)                GLog.i( Messages.get(this, "cursed") );
-			else {
-				ArrayList<Integer> spawnPoints = new ArrayList<>();
-				for (int i = 0; i < PathFinder.NEIGHBOURS8.length; i++) {
-					int p = hero.pos + PathFinder.NEIGHBOURS8[i];
-					if (Actor.findChar(p) == null && (Dungeon.level.passable[p] || Dungeon.level.avoid[p])) {
-						spawnPoints.add(p);
-					}
-				}
-
-				if (spawnPoints.size() > 0) {
-					ghost = new GhostHero( this );
-					ghostID = ghost.id();
-					ghost.pos = Random.element(spawnPoints);
-
-					GameScene.add(ghost, 1f);
-					Dungeon.level.occupyCell(ghost);
-					
-					CellEmitter.get(ghost.pos).start( ShaftParticle.FACTORY, 0.3f, 4 );
-					CellEmitter.get(ghost.pos).start( Speck.factory(Speck.LIGHT), 0.2f, 3 );
-
-					hero.spend(1f);
-					hero.busy();
-					hero.sprite.operate(hero.pos);
-
-					if (!firstSummon) {
-						ghost.yell( Messages.get(GhostHero.class, "hello", Messages.titleCase(Dungeon.hero.name())) );
-						Sample.INSTANCE.play( Assets.Sounds.GHOST );
-						firstSummon = true;
-						
-					} else {
-						if (BossHealthBar.isAssigned()) {
-							ghost.sayBoss();
-						} else {
-							ghost.sayAppeared();
-						}
-					}
-
-					Invisibility.dispel(hero);
-					Talent.onArtifactUsed(hero);
-					charge = 0;
-					partialCharge = 0;
-					updateQuickslot();
-
-				} else
-					GLog.i( Messages.get(this, "no_space") );
-			}
-
-		} else if (action.equals(AC_DIRECT)){
-			if (ghost == null && ghostID != 0){
-				Actor a = Actor.findById(ghostID);
-				if (a != null){
-					ghost = (GhostHero)a;
-				} else {
-					ghostID = 0;
-				}
-			}
-			if (ghost != null) GameScene.selectCell(ghostDirector);
-			
-		} else if (action.equals(AC_OUTFIT)){
-			GameScene.show( new WndGhostHero(this) );
-		}
-	}
-	
-	public int ghostStrength(){
-		return 13 + level()/2;
-	}
-
-	@Override
-	public String desc() {
-		if (!Ghost.Quest.completed()
-				&& (ShatteredPixelDungeon.scene() instanceof GameScene || ShatteredPixelDungeon.scene() instanceof AlchemyScene)){
-			return Messages.get(this, "desc_no_quest");
-		}
-		
-		String desc = super.desc();
-
-		if (isEquipped( Dungeon.hero )){
-			if (!cursed){
-
-				if (level() < levelCap)
-					desc+= "\n\n" + Messages.get(this, "desc_hint");
-
-			} else {
-				desc += "\n\n" + Messages.get(this, "desc_cursed");
-			}
-		}
-
-		if (weapon != null || armor != null) {
-			desc += "\n";
-
-			if (weapon != null) {
-				desc += "\n" + Messages.get(this, "desc_weapon", weapon.title());
-			}
-
-			if (armor != null) {
-				desc += "\n" + Messages.get(this, "desc_armor", armor.title());
-			}
-		}
-		
-		return desc;
-	}
-	
-	@Override
-	public int value() {
-		if (weapon != null){
-			return -1;
-		}
-		if (armor != null){
-			return -1;
-		}
-		return super.value();
-	}
-
-	@Override
-	public String status() {
-		if (ghost == null && ghostID != 0){
-			try {
-				Actor a = Actor.findById(ghostID);
-				if (a != null) {
-					ghost = (GhostHero) a;
-				} else {
-					ghostID = 0;
-				}
-			} catch ( ClassCastException e ){
-				ShatteredPixelDungeon.reportException(e);
-				ghostID = 0;
-			}
-		}
-		if (ghost == null){
-			return super.status();
-		} else {
-			return ((ghost.HP*100) / ghost.HT) + "%";
-		}
-	}
-	
-	@Override
-	protected ArtifactBuff passiveBuff() {
-		return new roseRecharge();
-	}
-	
-	@Override
-	public void charge(Hero target, float amount) {
-		if (cursed || target.buff(MagicImmune.class) != null) return;
-
-		if (ghost == null){
-			if (charge < chargeCap) {
-				charge += Math.round(4*amount);
-				if (charge >= chargeCap) {
-					charge = chargeCap;
-					partialCharge = 0;
-					GLog.p(Messages.get(DriedRose.class, "charged"));
-				}
-				updateQuickslot();
-			}
-		} else {
-			int heal = Math.round((1 + level()/3f)*amount);
-			ghost.HP = Math.min( ghost.HT, ghost.HP + heal);
-			updateQuickslot();
-		}
-	}
-	
-	@Override
-	public Item upgrade() {
-		if (level() >= 9)
-			image = ItemSpriteSheet.ARTIFACT_ROSE3;
-		else if (level() >= 4)
-			image = ItemSpriteSheet.ARTIFACT_ROSE2;
-
-		//For upgrade transferring via well of transmutation
-		droppedPetals = Math.max( level(), droppedPetals );
-		
-		if (ghost != null){
-			ghost.updateRose();
-		}
-
-		return super.upgrade();
-	}
-	
-	public Weapon ghostWeapon(){
-		return weapon;
-	}
-	
-	public Armor ghostArmor(){
-		return armor;
-	}
-
-	private static final String TALKEDTO =      "talkedto";
-	private static final String FIRSTSUMMON =   "firstsummon";
-	private static final String GHOSTID =       "ghostID";
-	private static final String PETALS =        "petals";
-	
-	private static final String WEAPON =        "weapon";
-	private static final String ARMOR =         "armor";
-
-	@Override
-	public void storeInBundle( Bundle bundle ) {
-		super.storeInBundle(bundle);
-
-		bundle.put( TALKEDTO, talkedTo );
-		bundle.put( FIRSTSUMMON, firstSummon );
-		bundle.put( GHOSTID, ghostID );
-		bundle.put( PETALS, droppedPetals );
-		
-		if (weapon != null) bundle.put( WEAPON, weapon );
-		if (armor != null)  bundle.put( ARMOR, armor );
-	}
-
-	@Override
-	public void restoreFromBundle( Bundle bundle ) {
-		super.restoreFromBundle(bundle);
-
-		talkedTo = bundle.getBoolean( TALKEDTO );
-		firstSummon = bundle.getBoolean( FIRSTSUMMON );
-		ghostID = bundle.getInt( GHOSTID );
-		droppedPetals = bundle.getInt( PETALS );
-		
-		if (bundle.contains(WEAPON)) weapon = (MeleeWeapon)bundle.get( WEAPON );
-		if (bundle.contains(ARMOR))  armor = (Armor)bundle.get( ARMOR );
-	}
-
-	public class roseRecharge extends ArtifactBuff {
-
-		@Override
-		public boolean act() {
-			
-			spend( TICK );
-			
-			if (ghost == null && ghostID != 0){
-				Actor a = Actor.findById(ghostID);
-				if (a != null){
-					ghost = (GhostHero)a;
-				} else {
-					ghostID = 0;
-				}
-			}
-
-			if (ghost != null && !ghost.isAlive()){
-				ghost = null;
-			}
-			
-			//rose does not charge while ghost hero is alive
-			if (ghost != null && !cursed && target.buff(MagicImmune.class) == null){
-				
-				//heals to full over 500 turns
-				if (ghost.HP < ghost.HT && Regeneration.regenOn()) {
-					partialCharge += (ghost.HT / 500f) * RingOfEnergy.artifactChargeMultiplier(target);
-					updateQuickslot();
-					
-					if (partialCharge > 1) {
-						ghost.HP++;
-						partialCharge--;
-					}
-				} else {
-					partialCharge = 0;
-				}
-				
-				return true;
-			}
-			
-			if (charge < chargeCap
-					&& !cursed
-					&& target.buff(MagicImmune.class) == null
-					&& Regeneration.regenOn()) {
-				//500 turns to a full charge
-				partialCharge += (1/5f * RingOfEnergy.artifactChargeMultiplier(target));
-				if (partialCharge > 1){
-					charge++;
-					partialCharge--;
-					if (charge == chargeCap){
-						partialCharge = 0f;
-						GLog.p( Messages.get(DriedRose.class, "charged") );
-					}
-				}
-			} else if (cursed && Random.Int(100) == 0) {
-
-				ArrayList<Integer> spawnPoints = new ArrayList<>();
-
-				for (int i = 0; i < PathFinder.NEIGHBOURS8.length; i++) {
-					int p = target.pos + PathFinder.NEIGHBOURS8[i];
-					if (Actor.findChar(p) == null && (Dungeon.level.passable[p] || Dungeon.level.avoid[p])) {
-						spawnPoints.add(p);
-					}
-				}
-
-				if (spawnPoints.size() > 0) {
-					Wraith.spawnAt(Random.element(spawnPoints), false);
-					Sample.INSTANCE.play(Assets.Sounds.CURSED);
-				}
-
-			}
-
-			updateQuickslot();
-
-			return true;
-		}
-	}
-	
-	public CellSelector.Listener ghostDirector = new CellSelector.Listener(){
-		
-		@Override
-		public void onSelect(Integer cell) {
-			if (cell == null) return;
-			
-			Sample.INSTANCE.play( Assets.Sounds.GHOST );
-
-			ghost.directTocell(cell);
-
-		}
-		
-		@Override
-		public String prompt() {
-			return  "\"" + Messages.get(GhostHero.class, "direct_prompt") + "\"";
-		}
-	};
-
-	public static class Petal extends Item {
-
-		{
-			stackable = true;
-			dropsDownHeap = true;
-			
-			image = ItemSpriteSheet.PETAL;
-		}
-
-		@Override
-		public boolean doPickUp(Hero hero, int pos) {
-			DriedRose rose = hero.belongings.getItem( DriedRose.class );
-
-			if (rose == null){
-				GLog.w( Messages.get(this, "no_rose") );
-				return false;
-			} if ( rose.level() >= rose.levelCap ){
-				GLog.i( Messages.get(this, "no_room") );
-				hero.spendAndNext(TIME_TO_PICK_UP);
-				return true;
-			} else {
-
-				rose.upgrade();
-				if (rose.level() == rose.levelCap) {
-					GLog.p( Messages.get(this, "maxlevel") );
-				} else
-					GLog.i( Messages.get(this, "levelup") );
-
-				Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-				GameScene.pickUp(this, pos);
-				hero.spendAndNext(TIME_TO_PICK_UP);
-				return true;
-
-			}
-		}
-
-		@Override
-		public boolean isUpgradable() {
-			return false;
-		}
-
-		@Override
-		public boolean isIdentified() {
-			return true;
-		}
-
-	}
-
-	public static class GhostHero extends DirectableAlly {
-
-		{
-			spriteClass = GhostSprite.class;
-
-			flying = true;
-			
-			state = HUNTING;
-			
-			properties.add(Property.UNDEAD);
-		}
-		
-		private DriedRose rose = null;
-		
-		public GhostHero(){
-			super();
-		}
-
-		public GhostHero(DriedRose rose){
-			super();
-			this.rose = rose;
-			updateRose();
-			HP = HT;
-		}
-
-		@Override
-		public void defendPos(int cell) {
-			yell(Messages.get(this, "directed_position_" + Random.IntRange(1, 5)));
-			super.defendPos(cell);
-		}
-
-		@Override
-		public void followHero() {
-			yell(Messages.get(this, "directed_follow_" + Random.IntRange(1, 5)));
-			super.followHero();
-		}
-
-		@Override
-		public void targetChar(Char ch) {
-			yell(Messages.get(this, "directed_attack_" + Random.IntRange(1, 5)));
-			super.targetChar(ch);
-		}
-
-		private void updateRose(){
-			if (rose == null) {
-				rose = Dungeon.hero.belongings.getItem(DriedRose.class);
-			}
-			
-			//same dodge as the hero
-			defenseSkill = (Dungeon.hero.lvl+4);
-			if (rose == null) return;
-			HT = 20 + 8*rose.level();
-		}
-
-		@Override
-		protected boolean act() {
-			updateRose();
-			if (rose == null
-					|| !rose.isEquipped(Dungeon.hero)
-					|| Dungeon.hero.buff(MagicImmune.class) != null){
-				damage(1, this);
-			}
-			
-			if (!isAlive()) {
-				return true;
-			}
-			return super.act();
-		}
-
-		@Override
-		public int attackSkill(Char target) {
-			
-			//same accuracy as the hero.
-			int acc = Dungeon.hero.lvl + 9;
-			
-			if (rose != null && rose.weapon != null){
-				acc *= rose.weapon.accuracyFactor( this, target );
-			}
-			
-			return acc;
-		}
-		
-		@Override
-		public float attackDelay() {
-			float delay = super.attackDelay();
-			if (rose != null && rose.weapon != null){
-				delay *= rose.weapon.delayFactor(this);
-			}
-			return delay;
-		}
-		
-		@Override
-		protected boolean canAttack(Char enemy) {
-			return super.canAttack(enemy) || (rose != null && rose.weapon != null && rose.weapon.canReach(this, enemy.pos));
-		}
-		
-		@Override
-		public int damageRoll() {
-			int dmg = 0;
-			if (rose != null && rose.weapon != null){
-				dmg += rose.weapon.damageRoll(this);
-			} else {
-				dmg += Random.NormalIntRange(0, 5);
-			}
-			
-			return dmg;
-		}
-		
-		@Override
-		public int attackProc(Char enemy, int damage) {
-			damage = super.attackProc(enemy, damage);
-			if (rose != null && rose.weapon != null) {
-				damage = rose.weapon.proc( this, enemy, damage );
-				if (!enemy.isAlive() && enemy == Dungeon.hero){
-					Dungeon.fail(this);
-					GLog.n( Messages.capitalize(Messages.get(Char.class, "kill", name())) );
-				}
-			}
-			return damage;
-		}
-		
-		@Override
-		public int defenseProc(Char enemy, int damage) {
-			if (rose != null && rose.armor != null) {
-				damage = rose.armor.proc( enemy, this, damage );
-			}
-			return super.defenseProc(enemy, damage);
-		}
-		
-		@Override
-		public void damage(int dmg, Object src) {
-			//TODO improve this when I have proper damage source logic
-			if (rose != null && rose.armor != null && rose.armor.hasGlyph(AntiMagic.class, this)
-					&& AntiMagic.RESISTS.contains(src.getClass())){
-				dmg -= AntiMagic.drRoll(this, rose.armor.buffedLvl());
-			}
-			
-			super.damage( dmg, src );
-			
-			//for the rose status indicator
-			Item.updateQuickslot();
-		}
-		
-		@Override
-		public float speed() {
-			float speed = super.speed();
-			
-			if (rose != null && rose.armor != null){
-				speed = rose.armor.speedFactor(this, speed);
-			}
-
-			//moves 2 tiles at a time when returning to the hero
-			if (state == WANDERING
-					&& defendingPos == -1
-					&& Dungeon.level.distance(pos, Dungeon.hero.pos) > 1){
-				speed *= 2;
-			}
-			
-			return speed;
-		}
-		
-		@Override
-		public int defenseSkill(Char enemy) {
-			int defense = super.defenseSkill(enemy);
-
-			if (defense != 0 && rose != null && rose.armor != null ){
-				defense = Math.round(rose.armor.evasionFactor( this, defense ));
-			}
-			
-			return defense;
-		}
-		
-		@Override
-		public float stealth() {
-			float stealth = super.stealth();
-			
-			if (rose != null && rose.armor != null){
-				stealth = rose.armor.stealthFactor(this, stealth);
-			}
-			
-			return stealth;
-		}
-		
-		@Override
-		public int drRoll() {
-			int dr = super.drRoll();
-			if (rose != null && rose.armor != null){
-				dr += Random.NormalIntRange( rose.armor.DRMin(), rose.armor.DRMax());
-			}
-			if (rose != null && rose.weapon != null){
-				dr += Random.NormalIntRange( 0, rose.weapon.defenseFactor( this ));
-			}
-			return dr;
-		}
-
-		//used in some glyph calculations
-		public Armor armor(){
-			if (rose != null){
-				return rose.armor;
-			} else {
-				return null;
-			}
-		}
-
-		@Override
-		public boolean isImmune(Class effect) {
-			if (effect == Burning.class
-					&& rose != null
-					&& rose.armor != null
-					&& rose.armor.hasGlyph(Brimstone.class, this)){
-				return true;
-			}
-			return super.isImmune(effect);
-		}
-
-		@Override
-		public boolean interact(Char c) {
-			updateRose();
-			if (c == Dungeon.hero && rose != null && !rose.talkedTo){
-				rose.talkedTo = true;
-				Game.runOnRenderThread(new Callback() {
-					@Override
-					public void call() {
-						GameScene.show(new WndQuest(GhostHero.this, Messages.get(GhostHero.this, "introduce") ));
-					}
-				});
-				return true;
-			} else {
-				return super.interact(c);
-			}
-		}
-
-		@Override
-		public void die(Object cause) {
-			sayDefeated();
-			super.die(cause);
-		}
-
-		@Override
-		public void destroy() {
-			updateRose();
-			if (rose != null) {
-				rose.ghost = null;
-				rose.charge = 0;
-				rose.partialCharge = 0;
-				rose.ghostID = -1;
-			}
-			super.destroy();
-		}
-		
-		public void sayAppeared(){
-			if (Dungeon.hero.buff(AscensionChallenge.class) != null){
-				yell( Messages.get( this, "dialogue_ascension_" + Random.IntRange(1, 6) ));
-
-			} else {
-
-				int depth = (Dungeon.depth - 1) / 5;
-
-				//only some lines are said on the first floor of a depth
-				int variant = Dungeon.depth % 5 == 1 ? Random.IntRange(1, 3) : Random.IntRange(1, 6);
-
-				switch (depth) {
-					case 0:
-						yell(Messages.get(this, "dialogue_sewers_" + variant));
-						break;
-					case 1:
-						yell(Messages.get(this, "dialogue_prison_" + variant));
-						break;
-					case 2:
-						yell(Messages.get(this, "dialogue_caves_" + variant));
-						break;
-					case 3:
-						yell(Messages.get(this, "dialogue_city_" + variant));
-						break;
-					case 4:
-					default:
-						yell(Messages.get(this, "dialogue_halls_" + variant));
-						break;
-				}
-			}
-			if (ShatteredPixelDungeon.scene() instanceof GameScene) {
-				Sample.INSTANCE.play( Assets.Sounds.GHOST );
-			}
-		}
-		
-		public void sayBoss(){
-			int depth = (Dungeon.depth - 1) / 5;
-			
-			switch(depth){
-				case 0:
-					yell( Messages.get( this, "seen_goo_" + Random.IntRange(1, 3) ));
-					break;
-				case 1:
-					yell( Messages.get( this, "seen_tengu_" + Random.IntRange(1, 3) ));
-					break;
-				case 2:
-					yell( Messages.get( this, "seen_dm300_" + Random.IntRange(1, 3) ));
-					break;
-				case 3:
-					yell( Messages.get( this, "seen_king_" + Random.IntRange(1, 3) ));
-					break;
-				case 4: default:
-					yell( Messages.get( this, "seen_yog_" + Random.IntRange(1, 3) ));
-					break;
-			}
-			Sample.INSTANCE.play( Assets.Sounds.GHOST );
-		}
-		
-		public void sayDefeated(){
-			if (BossHealthBar.isAssigned()){
-				yell( Messages.get( this, "defeated_by_boss_" + Random.IntRange(1, 3) ));
-			} else {
-				yell( Messages.get( this, "defeated_by_enemy_" + Random.IntRange(1, 3) ));
-			}
-			Sample.INSTANCE.play( Assets.Sounds.GHOST );
-		}
-		
-		public void sayHeroKilled(){
-			yell( Messages.get( this, "player_killed_" + Random.IntRange(1, 3) ));
-			GLog.newLine();
-			Sample.INSTANCE.play( Assets.Sounds.GHOST );
-		}
-		
-		public void sayAnhk(){
-			yell( Messages.get( this, "blessed_ankh_" + Random.IntRange(1, 3) ));
-			Sample.INSTANCE.play( Assets.Sounds.GHOST );
-		}
-		
-		{
-			immunities.add( ToxicGas.class );
-			immunities.add( CorrosiveGas.class );
-			immunities.add( Burning.class );
-			immunities.add( ScrollOfRetribution.class );
-			immunities.add( ScrollOfPsionicBlast.class );
-			immunities.add( AllyBuff.class );
-		}
-
-	}
-	
-	private static class WndGhostHero extends Window{
-		
-		private static final int BTN_SIZE	= 32;
-		private static final float GAP		= 2;
-		private static final float BTN_GAP	= 12;
-		private static final int WIDTH		= 116;
-		
-		private WndBlacksmith.ItemButton btnWeapon;
-		private WndBlacksmith.ItemButton btnArmor;
-		
-		WndGhostHero(final DriedRose rose){
-			
-			IconTitle titlebar = new IconTitle();
-			titlebar.icon( new ItemSprite(rose) );
-			titlebar.label( Messages.get(this, "title") );
-			titlebar.setRect( 0, 0, WIDTH, 0 );
-			add( titlebar );
-			
-			RenderedTextBlock message =
-					PixelScene.renderTextBlock(Messages.get(this, "desc", rose.ghostStrength()), 6);
-			message.maxWidth( WIDTH );
-			message.setPos(0, titlebar.bottom() + GAP);
-			add( message );
-			
-			btnWeapon = new WndBlacksmith.ItemButton(){
-				@Override
-				protected void onClick() {
-					if (rose.weapon != null){
-						item(new WndBag.Placeholder(ItemSpriteSheet.WEAPON_HOLDER));
-						if (!rose.weapon.doPickUp(Dungeon.hero)){
-							Dungeon.level.drop( rose.weapon, Dungeon.hero.pos);
-						}
-						rose.weapon = null;
-					} else {
-						GameScene.selectItem(new WndBag.ItemSelector() {
-
-							@Override
-							public String textPrompt() {
-								return Messages.get(WndGhostHero.class, "weapon_prompt");
-							}
-
-							@Override
-							public Class<?extends Bag> preferredBag(){
-								return Belongings.Backpack.class;
-							}
-
-							@Override
-							public boolean itemSelectable(Item item) {
-								return item instanceof MeleeWeapon;
-							}
-
-							@Override
-							public void onSelect(Item item) {
-								if (!(item instanceof MeleeWeapon)) {
-									//do nothing, should only happen when window is cancelled
-								} else if (item.unique) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_unique"));
-									hide();
-								} else if (!item.isIdentified()) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_unidentified"));
-									hide();
-								} else if (item.cursed) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_cursed"));
-									hide();
-								} else if (((MeleeWeapon)item).STRReq() > rose.ghostStrength()) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_strength"));
-									hide();
-								} else {
-									if (item.isEquipped(Dungeon.hero)){
-										((MeleeWeapon) item).doUnequip(Dungeon.hero, false, false);
-									} else {
-										item.detach(Dungeon.hero.belongings.backpack);
-									}
-									rose.weapon = (MeleeWeapon) item;
-									item(rose.weapon);
-								}
-								
-							}
-						});
-					}
-				}
-			};
-			btnWeapon.setRect( (WIDTH - BTN_GAP) / 2 - BTN_SIZE, message.top() + message.height() + GAP, BTN_SIZE, BTN_SIZE );
-			if (rose.weapon != null) {
-				btnWeapon.item(rose.weapon);
-			} else {
-				btnWeapon.item(new WndBag.Placeholder(ItemSpriteSheet.WEAPON_HOLDER));
-			}
-			add( btnWeapon );
-			
-			btnArmor = new WndBlacksmith.ItemButton(){
-				@Override
-				protected void onClick() {
-					if (rose.armor != null){
-						item(new WndBag.Placeholder(ItemSpriteSheet.ARMOR_HOLDER));
-						if (!rose.armor.doPickUp(Dungeon.hero)){
-							Dungeon.level.drop( rose.armor, Dungeon.hero.pos);
-						}
-						rose.armor = null;
-					} else {
-						GameScene.selectItem(new WndBag.ItemSelector() {
-
-							@Override
-							public String textPrompt() {
-								return Messages.get(WndGhostHero.class, "armor_prompt");
-							}
-
-							@Override
-							public Class<?extends Bag> preferredBag(){
-								return Belongings.Backpack.class;
-							}
-
-							@Override
-							public boolean itemSelectable(Item item) {
-								return item instanceof Armor;
-							}
-
-							@Override
-							public void onSelect(Item item) {
-								if (!(item instanceof Armor)) {
-									//do nothing, should only happen when window is cancelled
-								} else if (item.unique || ((Armor) item).checkSeal() != null) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_unique"));
-									hide();
-								} else if (!item.isIdentified()) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_unidentified"));
-									hide();
-								} else if (item.cursed) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_cursed"));
-									hide();
-								} else if (((Armor)item).STRReq() > rose.ghostStrength()) {
-									GLog.w( Messages.get(WndGhostHero.class, "cant_strength"));
-									hide();
-								} else {
-									if (item.isEquipped(Dungeon.hero)){
-										((Armor) item).doUnequip(Dungeon.hero, false, false);
-									} else {
-										item.detach(Dungeon.hero.belongings.backpack);
-									}
-									rose.armor = (Armor) item;
-									item(rose.armor);
-								}
-								
-							}
-						});
-					}
-				}
-			};
-			btnArmor.setRect( btnWeapon.right() + BTN_GAP, btnWeapon.top(), BTN_SIZE, BTN_SIZE );
-			if (rose.armor != null) {
-				btnArmor.item(rose.armor);
-			} else {
-				btnArmor.item(new WndBag.Placeholder(ItemSpriteSheet.ARMOR_HOLDER));
-			}
-			add( btnArmor );
-			
-			resize(WIDTH, (int)(btnArmor.bottom() + GAP));
-		}
-	
-	}
+    {
+        image = ItemSpriteSheet.ARTIFACT_ROSE1;
+
+        levelCap = 10;
+
+        charge = 100;
+        chargeCap = 100;
+
+        defaultAction = AC_SUMMON;
+    }
+
+    private boolean talkedTo = false;
+    private boolean firstSummon = false;
+
+    private GhostHero ghost = null;
+    private int ghostID = 0;
+
+    private MeleeWeapon weapon = null;
+    private Armor armor = null;
+
+    public int droppedPetals = 0;
+
+    public static final String AC_SUMMON = "SUMMON";
+    public static final String AC_DIRECT = "DIRECT";
+    public static final String AC_OUTFIT = "OUTFIT";
+
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        if (!Ghost.Quest.completed()) {
+            return actions;
+        }
+        if (isEquipped(hero)
+                && charge == chargeCap
+                && !cursed
+                && hero.buff(MagicImmune.class) == null
+                && ghostID == 0) {
+            actions.add(AC_SUMMON);
+        }
+        if (ghostID != 0) {
+            actions.add(AC_DIRECT);
+        }
+        if (isIdentified() && !cursed) {
+            actions.add(AC_OUTFIT);
+        }
+
+        return actions;
+    }
+
+    @Override
+    public String defaultAction() {
+        if (ghost != null) {
+            return AC_DIRECT;
+        } else {
+            return AC_SUMMON;
+        }
+    }
+
+    @Override
+    public void execute(Hero hero, String action) {
+
+        super.execute(hero, action);
+
+        if (action.equals(AC_SUMMON)) {
+
+            if (hero.buff(MagicImmune.class) != null)
+                return;
+
+            if (!Ghost.Quest.completed())
+                GameScene.show(new WndUseItem(null, this));
+            else if (ghost != null)
+                GLog.i(Messages.get(this, "spawned"));
+            else if (!isEquipped(hero))
+                GLog.i(Messages.get(Artifact.class, "need_to_equip"));
+            else if (charge != chargeCap)
+                GLog.i(Messages.get(this, "no_charge"));
+            else if (cursed)
+                GLog.i(Messages.get(this, "cursed"));
+            else {
+                ArrayList<Integer> spawnPoints = new ArrayList<>();
+                for (int i = 0; i < PathFinder.NEIGHBOURS8.length; i++) {
+                    int p = hero.pos + PathFinder.NEIGHBOURS8[i];
+                    if (Actor.findChar(p) == null && (Dungeon.level.passable[p] || Dungeon.level.avoid[p])) {
+                        spawnPoints.add(p);
+                    }
+                }
+
+                if (spawnPoints.size() > 0) {
+                    ghost = new GhostHero(this);
+                    ghostID = ghost.id();
+                    ghost.pos = Random.element(spawnPoints);
+
+                    GameScene.add(ghost, 1f);
+                    Dungeon.level.occupyCell(ghost);
+
+                    CellEmitter.get(ghost.pos).start(ShaftParticle.FACTORY, 0.3f, 4);
+                    CellEmitter.get(ghost.pos).start(Speck.factory(Speck.LIGHT), 0.2f, 3);
+
+                    hero.spend(1f);
+                    hero.busy();
+                    hero.sprite.operate(hero.pos);
+
+                    if (!firstSummon) {
+                        ghost.yell(Messages.get(GhostHero.class, "hello", Messages.titleCase(Dungeon.hero.name())));
+                        Sample.INSTANCE.play(Assets.Sounds.GHOST);
+                        firstSummon = true;
+
+                    } else {
+                        if (BossHealthBar.isAssigned()) {
+                            ghost.sayBoss();
+                        } else {
+                            ghost.sayAppeared();
+                        }
+                    }
+
+                    Invisibility.dispel(hero);
+                    Talent.onArtifactUsed(hero);
+                    charge = 0;
+                    partialCharge = 0;
+                    updateQuickslot();
+
+                } else
+                    GLog.i(Messages.get(this, "no_space"));
+            }
+
+        } else if (action.equals(AC_DIRECT)) {
+            if (ghost == null && ghostID != 0) {
+                Actor a = Actor.findById(ghostID);
+                if (a != null) {
+                    ghost = (GhostHero) a;
+                } else {
+                    ghostID = 0;
+                }
+            }
+            if (ghost != null)
+                GameScene.selectCell(ghostDirector);
+
+        } else if (action.equals(AC_OUTFIT)) {
+            GameScene.show(new WndGhostHero(this));
+        }
+    }
+
+    public int ghostStrength() {
+        return 13 + level() / 2;
+    }
+
+    @Override
+    public String desc() {
+        if (!Ghost.Quest.completed()
+                && (ShatteredPixelDungeon.scene() instanceof GameScene
+                        || ShatteredPixelDungeon.scene() instanceof AlchemyScene)) {
+            return Messages.get(this, "desc_no_quest");
+        }
+
+        String desc = super.desc();
+
+        if (isEquipped(Dungeon.hero)) {
+            if (!cursed) {
+
+                if (level() < levelCap)
+                    desc += "\n\n" + Messages.get(this, "desc_hint");
+
+            } else {
+                desc += "\n\n" + Messages.get(this, "desc_cursed");
+            }
+        }
+
+        if (weapon != null || armor != null) {
+            desc += "\n";
+
+            if (weapon != null) {
+                desc += "\n" + Messages.get(this, "desc_weapon", weapon.title());
+            }
+
+            if (armor != null) {
+                desc += "\n" + Messages.get(this, "desc_armor", armor.title());
+            }
+        }
+
+        return desc;
+    }
+
+    @Override
+    public int value() {
+        if (weapon != null) {
+            return -1;
+        }
+        if (armor != null) {
+            return -1;
+        }
+        return super.value();
+    }
+
+    @Override
+    public String status() {
+        if (ghost == null && ghostID != 0) {
+            try {
+                Actor a = Actor.findById(ghostID);
+                if (a != null) {
+                    ghost = (GhostHero) a;
+                } else {
+                    ghostID = 0;
+                }
+            } catch (ClassCastException e) {
+                ShatteredPixelDungeon.reportException(e);
+                ghostID = 0;
+            }
+        }
+        if (ghost == null) {
+            return super.status();
+        } else {
+            return ((ghost.HP * 100) / ghost.HT) + "%";
+        }
+    }
+
+    @Override
+    protected ArtifactBuff passiveBuff() {
+        return new roseRecharge();
+    }
+
+    @Override
+    public void charge(Hero target, float amount) {
+        if (cursed || target.buff(MagicImmune.class) != null)
+            return;
+
+        if (ghost == null) {
+            if (charge < chargeCap) {
+                charge += Math.round(4 * amount);
+                if (charge >= chargeCap) {
+                    charge = chargeCap;
+                    partialCharge = 0;
+                    GLog.p(Messages.get(DriedRose.class, "charged"));
+                }
+                updateQuickslot();
+            }
+        } else {
+            int heal = Math.round((1 + level() / 3f) * amount);
+            ghost.HP = Math.min(ghost.HT, ghost.HP + heal);
+            updateQuickslot();
+        }
+    }
+
+    @Override
+    public Item upgrade() {
+        if (level() >= 9)
+            image = ItemSpriteSheet.ARTIFACT_ROSE3;
+        else if (level() >= 4)
+            image = ItemSpriteSheet.ARTIFACT_ROSE2;
+
+        // For upgrade transferring via well of transmutation
+        droppedPetals = Math.max(level(), droppedPetals);
+
+        if (ghost != null) {
+            ghost.updateRose();
+        }
+
+        return super.upgrade();
+    }
+
+    public Weapon ghostWeapon() {
+        return weapon;
+    }
+
+    public Armor ghostArmor() {
+        return armor;
+    }
+
+    private static final String TALKEDTO = "talkedto";
+    private static final String FIRSTSUMMON = "firstsummon";
+    private static final String GHOSTID = "ghostID";
+    private static final String PETALS = "petals";
+
+    private static final String WEAPON = "weapon";
+    private static final String ARMOR = "armor";
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+
+        bundle.put(TALKEDTO, talkedTo);
+        bundle.put(FIRSTSUMMON, firstSummon);
+        bundle.put(GHOSTID, ghostID);
+        bundle.put(PETALS, droppedPetals);
+
+        if (weapon != null)
+            bundle.put(WEAPON, weapon);
+        if (armor != null)
+            bundle.put(ARMOR, armor);
+    }
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        super.restoreFromBundle(bundle);
+
+        talkedTo = bundle.getBoolean(TALKEDTO);
+        firstSummon = bundle.getBoolean(FIRSTSUMMON);
+        ghostID = bundle.getInt(GHOSTID);
+        droppedPetals = bundle.getInt(PETALS);
+
+        if (bundle.contains(WEAPON))
+            weapon = (MeleeWeapon) bundle.get(WEAPON);
+        if (bundle.contains(ARMOR))
+            armor = (Armor) bundle.get(ARMOR);
+    }
+
+    public class roseRecharge extends ArtifactBuff {
+
+        @Override
+        public boolean act() {
+
+            spend(TICK);
+
+            if (ghost == null && ghostID != 0) {
+                Actor a = Actor.findById(ghostID);
+                if (a != null) {
+                    ghost = (GhostHero) a;
+                } else {
+                    ghostID = 0;
+                }
+            }
+
+            if (ghost != null && !ghost.isAlive()) {
+                ghost = null;
+            }
+
+            // rose does not charge while ghost hero is alive
+            if (ghost != null && !cursed && target.buff(MagicImmune.class) == null) {
+
+                // heals to full over 500 turns
+                if (ghost.HP < ghost.HT && Regeneration.regenOn()) {
+                    partialCharge += (ghost.HT / 500f) * RingOfEnergy.artifactChargeMultiplier(target);
+                    updateQuickslot();
+
+                    if (partialCharge > 1) {
+                        ghost.HP++;
+                        partialCharge--;
+                    }
+                } else {
+                    partialCharge = 0;
+                }
+
+                return true;
+            }
+
+            if (charge < chargeCap
+                    && !cursed
+                    && target.buff(MagicImmune.class) == null
+                    && Regeneration.regenOn()) {
+                // 500 turns to a full charge
+                partialCharge += (1 / 5f * RingOfEnergy.artifactChargeMultiplier(target));
+                if (partialCharge > 1) {
+                    charge++;
+                    partialCharge--;
+                    if (charge == chargeCap) {
+                        partialCharge = 0f;
+                        GLog.p(Messages.get(DriedRose.class, "charged"));
+                    }
+                }
+            } else if (cursed && Random.Int(100) == 0) {
+
+                ArrayList<Integer> spawnPoints = new ArrayList<>();
+
+                for (int i = 0; i < PathFinder.NEIGHBOURS8.length; i++) {
+                    int p = target.pos + PathFinder.NEIGHBOURS8[i];
+                    if (Actor.findChar(p) == null && (Dungeon.level.passable[p] || Dungeon.level.avoid[p])) {
+                        spawnPoints.add(p);
+                    }
+                }
+
+                if (spawnPoints.size() > 0) {
+                    Wraith.spawnAt(Random.element(spawnPoints), false);
+                    Sample.INSTANCE.play(Assets.Sounds.CURSED);
+                }
+
+            }
+
+            updateQuickslot();
+
+            return true;
+        }
+    }
+
+    public CellSelector.Listener ghostDirector = new CellSelector.Listener() {
+
+        @Override
+        public void onSelect(Integer cell) {
+            if (cell == null)
+                return;
+
+            Sample.INSTANCE.play(Assets.Sounds.GHOST);
+
+            ghost.directTocell(cell);
+
+        }
+
+        @Override
+        public String prompt() {
+            return "\"" + Messages.get(GhostHero.class, "direct_prompt") + "\"";
+        }
+    };
+
+    public static class Petal extends Item {
+
+        {
+            stackable = true;
+            dropsDownHeap = true;
+
+            image = ItemSpriteSheet.PETAL;
+        }
+
+        @Override
+        public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+            DriedRose rose = hero.belongings.getItem(DriedRose.class);
+
+            if (rose == null) {
+                GLog.w(Messages.get(this, "no_rose"));
+                return false;
+            }
+
+            if (rose.level() >= rose.levelCap) {
+                GLog.i(Messages.get(this, "no_room"));
+                if (!isAutoLoot)
+                    hero.spendAndNext(TIME_TO_PICK_UP);
+                return true;
+            } else {
+                rose.upgrade();
+                if (rose.level() == rose.levelCap) {
+                    GLog.p(Messages.get(this, "maxlevel"));
+                } else
+                    GLog.i(Messages.get(this, "levelup"));
+
+                Sample.INSTANCE.play(Assets.Sounds.DEWDROP);
+                GameScene.pickUp(this, pos);
+                if (!isAutoLoot)
+                    hero.spendAndNext(TIME_TO_PICK_UP);
+                return true;
+
+            }
+        }
+
+        @Override
+        public boolean isUpgradable() {
+            return false;
+        }
+
+        @Override
+        public boolean isIdentified() {
+            return true;
+        }
+
+    }
+
+    public static class GhostHero extends DirectableAlly {
+
+        {
+            spriteClass = GhostSprite.class;
+
+            flying = true;
+
+            state = HUNTING;
+
+            properties.add(Property.UNDEAD);
+        }
+
+        private DriedRose rose = null;
+
+        public GhostHero() {
+            super();
+        }
+
+        public GhostHero(DriedRose rose) {
+            super();
+            this.rose = rose;
+            updateRose();
+            HP = HT;
+        }
+
+        @Override
+        public void defendPos(int cell) {
+            yell(Messages.get(this, "directed_position_" + Random.IntRange(1, 5)));
+            super.defendPos(cell);
+        }
+
+        @Override
+        public void followHero() {
+            yell(Messages.get(this, "directed_follow_" + Random.IntRange(1, 5)));
+            super.followHero();
+        }
+
+        @Override
+        public void targetChar(Char ch) {
+            yell(Messages.get(this, "directed_attack_" + Random.IntRange(1, 5)));
+            super.targetChar(ch);
+        }
+
+        private void updateRose() {
+            if (rose == null) {
+                rose = Dungeon.hero.belongings.getItem(DriedRose.class);
+            }
+
+            // same dodge as the hero
+            defenseSkill = (Dungeon.hero.lvl + 4);
+            if (rose == null)
+                return;
+            HT = 20 + 8 * rose.level();
+        }
+
+        @Override
+        protected boolean act() {
+            updateRose();
+            if (rose == null
+                    || !rose.isEquipped(Dungeon.hero)
+                    || Dungeon.hero.buff(MagicImmune.class) != null) {
+                damage(1, this);
+            }
+
+            if (!isAlive()) {
+                return true;
+            }
+            return super.act();
+        }
+
+        @Override
+        public int attackSkill(Char target) {
+
+            // same accuracy as the hero.
+            int acc = Dungeon.hero.lvl + 9;
+
+            if (rose != null && rose.weapon != null) {
+                acc *= rose.weapon.accuracyFactor(this, target);
+            }
+
+            return acc;
+        }
+
+        @Override
+        public float attackDelay() {
+            float delay = super.attackDelay();
+            if (rose != null && rose.weapon != null) {
+                delay *= rose.weapon.delayFactor(this);
+            }
+            return delay;
+        }
+
+        @Override
+        protected boolean canAttack(Char enemy) {
+            return super.canAttack(enemy)
+                    || (rose != null && rose.weapon != null && rose.weapon.canReach(this, enemy.pos));
+        }
+
+        @Override
+        public int damageRoll() {
+            int dmg = 0;
+            if (rose != null && rose.weapon != null) {
+                dmg += rose.weapon.damageRoll(this);
+            } else {
+                dmg += Random.NormalIntRange(0, 5);
+            }
+
+            return dmg;
+        }
+
+        @Override
+        public int attackProc(Char enemy, int damage) {
+            damage = super.attackProc(enemy, damage);
+            if (rose != null && rose.weapon != null) {
+                damage = rose.weapon.proc(this, enemy, damage);
+                if (!enemy.isAlive() && enemy == Dungeon.hero) {
+                    Dungeon.fail(this);
+                    GLog.n(Messages.capitalize(Messages.get(Char.class, "kill", name())));
+                }
+            }
+            return damage;
+        }
+
+        @Override
+        public int defenseProc(Char enemy, int damage) {
+            if (rose != null && rose.armor != null) {
+                damage = rose.armor.proc(enemy, this, damage);
+            }
+            return super.defenseProc(enemy, damage);
+        }
+
+        @Override
+        public void damage(int dmg, Object src) {
+            // TODO improve this when I have proper damage source logic
+            if (rose != null && rose.armor != null && rose.armor.hasGlyph(AntiMagic.class, this)
+                    && AntiMagic.RESISTS.contains(src.getClass())) {
+                dmg -= AntiMagic.drRoll(this, rose.armor.buffedLvl());
+            }
+
+            super.damage(dmg, src);
+
+            // for the rose status indicator
+            Item.updateQuickslot();
+        }
+
+        @Override
+        public float speed() {
+            float speed = super.speed();
+
+            if (rose != null && rose.armor != null) {
+                speed = rose.armor.speedFactor(this, speed);
+            }
+
+            // moves 2 tiles at a time when returning to the hero
+            if (state == WANDERING
+                    && defendingPos == -1
+                    && Dungeon.level.distance(pos, Dungeon.hero.pos) > 1) {
+                speed *= 2;
+            }
+
+            return speed;
+        }
+
+        @Override
+        public int defenseSkill(Char enemy) {
+            int defense = super.defenseSkill(enemy);
+
+            if (defense != 0 && rose != null && rose.armor != null) {
+                defense = Math.round(rose.armor.evasionFactor(this, defense));
+            }
+
+            return defense;
+        }
+
+        @Override
+        public float stealth() {
+            float stealth = super.stealth();
+
+            if (rose != null && rose.armor != null) {
+                stealth = rose.armor.stealthFactor(this, stealth);
+            }
+
+            return stealth;
+        }
+
+        @Override
+        public int drRoll() {
+            int dr = super.drRoll();
+            if (rose != null && rose.armor != null) {
+                dr += Random.NormalIntRange(rose.armor.DRMin(), rose.armor.DRMax());
+            }
+            if (rose != null && rose.weapon != null) {
+                dr += Random.NormalIntRange(0, rose.weapon.defenseFactor(this));
+            }
+            return dr;
+        }
+
+        // used in some glyph calculations
+        public Armor armor() {
+            if (rose != null) {
+                return rose.armor;
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public boolean isImmune(Class effect) {
+            if (effect == Burning.class
+                    && rose != null
+                    && rose.armor != null
+                    && rose.armor.hasGlyph(Brimstone.class, this)) {
+                return true;
+            }
+            return super.isImmune(effect);
+        }
+
+        @Override
+        public boolean interact(Char c) {
+            updateRose();
+            if (c == Dungeon.hero && rose != null && !rose.talkedTo) {
+                rose.talkedTo = true;
+                Game.runOnRenderThread(new Callback() {
+                    @Override
+                    public void call() {
+                        GameScene.show(new WndQuest(GhostHero.this, Messages.get(GhostHero.this, "introduce")));
+                    }
+                });
+                return true;
+            } else {
+                return super.interact(c);
+            }
+        }
+
+        @Override
+        public void die(Object cause) {
+            sayDefeated();
+            super.die(cause);
+        }
+
+        @Override
+        public void destroy() {
+            updateRose();
+            if (rose != null) {
+                rose.ghost = null;
+                rose.charge = 0;
+                rose.partialCharge = 0;
+                rose.ghostID = -1;
+            }
+            super.destroy();
+        }
+
+        public void sayAppeared() {
+            if (Dungeon.hero.buff(AscensionChallenge.class) != null) {
+                yell(Messages.get(this, "dialogue_ascension_" + Random.IntRange(1, 6)));
+
+            } else {
+
+                int depth = (Dungeon.depth - 1) / 5;
+
+                // only some lines are said on the first floor of a depth
+                int variant = Dungeon.depth % 5 == 1 ? Random.IntRange(1, 3) : Random.IntRange(1, 6);
+
+                switch (depth) {
+                    case 0:
+                        yell(Messages.get(this, "dialogue_sewers_" + variant));
+                        break;
+                    case 1:
+                        yell(Messages.get(this, "dialogue_prison_" + variant));
+                        break;
+                    case 2:
+                        yell(Messages.get(this, "dialogue_caves_" + variant));
+                        break;
+                    case 3:
+                        yell(Messages.get(this, "dialogue_city_" + variant));
+                        break;
+                    case 4:
+                    default:
+                        yell(Messages.get(this, "dialogue_halls_" + variant));
+                        break;
+                }
+            }
+            if (ShatteredPixelDungeon.scene() instanceof GameScene) {
+                Sample.INSTANCE.play(Assets.Sounds.GHOST);
+            }
+        }
+
+        public void sayBoss() {
+            int depth = (Dungeon.depth - 1) / 5;
+
+            switch (depth) {
+                case 0:
+                    yell(Messages.get(this, "seen_goo_" + Random.IntRange(1, 3)));
+                    break;
+                case 1:
+                    yell(Messages.get(this, "seen_tengu_" + Random.IntRange(1, 3)));
+                    break;
+                case 2:
+                    yell(Messages.get(this, "seen_dm300_" + Random.IntRange(1, 3)));
+                    break;
+                case 3:
+                    yell(Messages.get(this, "seen_king_" + Random.IntRange(1, 3)));
+                    break;
+                case 4:
+                default:
+                    yell(Messages.get(this, "seen_yog_" + Random.IntRange(1, 3)));
+                    break;
+            }
+            Sample.INSTANCE.play(Assets.Sounds.GHOST);
+        }
+
+        public void sayDefeated() {
+            if (BossHealthBar.isAssigned()) {
+                yell(Messages.get(this, "defeated_by_boss_" + Random.IntRange(1, 3)));
+            } else {
+                yell(Messages.get(this, "defeated_by_enemy_" + Random.IntRange(1, 3)));
+            }
+            Sample.INSTANCE.play(Assets.Sounds.GHOST);
+        }
+
+        public void sayHeroKilled() {
+            yell(Messages.get(this, "player_killed_" + Random.IntRange(1, 3)));
+            GLog.newLine();
+            Sample.INSTANCE.play(Assets.Sounds.GHOST);
+        }
+
+        public void sayAnhk() {
+            yell(Messages.get(this, "blessed_ankh_" + Random.IntRange(1, 3)));
+            Sample.INSTANCE.play(Assets.Sounds.GHOST);
+        }
+
+        {
+            immunities.add(ToxicGas.class);
+            immunities.add(CorrosiveGas.class);
+            immunities.add(Burning.class);
+            immunities.add(ScrollOfRetribution.class);
+            immunities.add(ScrollOfPsionicBlast.class);
+            immunities.add(AllyBuff.class);
+        }
+
+    }
+
+    private static class WndGhostHero extends Window {
+
+        private static final int BTN_SIZE = 32;
+        private static final float GAP = 2;
+        private static final float BTN_GAP = 12;
+        private static final int WIDTH = 116;
+
+        private WndBlacksmith.ItemButton btnWeapon;
+        private WndBlacksmith.ItemButton btnArmor;
+
+        WndGhostHero(final DriedRose rose) {
+
+            IconTitle titlebar = new IconTitle();
+            titlebar.icon(new ItemSprite(rose));
+            titlebar.label(Messages.get(this, "title"));
+            titlebar.setRect(0, 0, WIDTH, 0);
+            add(titlebar);
+
+            RenderedTextBlock message = PixelScene.renderTextBlock(Messages.get(this, "desc", rose.ghostStrength()), 6);
+            message.maxWidth(WIDTH);
+            message.setPos(0, titlebar.bottom() + GAP);
+            add(message);
+
+            btnWeapon = new WndBlacksmith.ItemButton() {
+                @Override
+                protected void onClick() {
+                    if (rose.weapon != null) {
+                        item(new WndBag.Placeholder(ItemSpriteSheet.WEAPON_HOLDER));
+                        if (!rose.weapon.doPickUp(Dungeon.hero)) {
+                            Dungeon.level.drop(rose.weapon, Dungeon.hero.pos);
+                        }
+                        rose.weapon = null;
+                    } else {
+                        GameScene.selectItem(new WndBag.ItemSelector() {
+
+                            @Override
+                            public String textPrompt() {
+                                return Messages.get(WndGhostHero.class, "weapon_prompt");
+                            }
+
+                            @Override
+                            public Class<? extends Bag> preferredBag() {
+                                return Belongings.Backpack.class;
+                            }
+
+                            @Override
+                            public boolean itemSelectable(Item item) {
+                                return item instanceof MeleeWeapon;
+                            }
+
+                            @Override
+                            public void onSelect(Item item) {
+                                if (!(item instanceof MeleeWeapon)) {
+                                    // do nothing, should only happen when window is cancelled
+                                } else if (item.unique) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_unique"));
+                                    hide();
+                                } else if (!item.isIdentified()) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_unidentified"));
+                                    hide();
+                                } else if (item.cursed) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_cursed"));
+                                    hide();
+                                } else if (((MeleeWeapon) item).STRReq() > rose.ghostStrength()) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_strength"));
+                                    hide();
+                                } else {
+                                    if (item.isEquipped(Dungeon.hero)) {
+                                        ((MeleeWeapon) item).doUnequip(Dungeon.hero, false, false);
+                                    } else {
+                                        item.detach(Dungeon.hero.belongings.backpack);
+                                    }
+                                    rose.weapon = (MeleeWeapon) item;
+                                    item(rose.weapon);
+                                }
+
+                            }
+                        });
+                    }
+                }
+            };
+            btnWeapon.setRect((WIDTH - BTN_GAP) / 2 - BTN_SIZE, message.top() + message.height() + GAP, BTN_SIZE,
+                    BTN_SIZE);
+            if (rose.weapon != null) {
+                btnWeapon.item(rose.weapon);
+            } else {
+                btnWeapon.item(new WndBag.Placeholder(ItemSpriteSheet.WEAPON_HOLDER));
+            }
+            add(btnWeapon);
+
+            btnArmor = new WndBlacksmith.ItemButton() {
+                @Override
+                protected void onClick() {
+                    if (rose.armor != null) {
+                        item(new WndBag.Placeholder(ItemSpriteSheet.ARMOR_HOLDER));
+                        if (!rose.armor.doPickUp(Dungeon.hero)) {
+                            Dungeon.level.drop(rose.armor, Dungeon.hero.pos);
+                        }
+                        rose.armor = null;
+                    } else {
+                        GameScene.selectItem(new WndBag.ItemSelector() {
+
+                            @Override
+                            public String textPrompt() {
+                                return Messages.get(WndGhostHero.class, "armor_prompt");
+                            }
+
+                            @Override
+                            public Class<? extends Bag> preferredBag() {
+                                return Belongings.Backpack.class;
+                            }
+
+                            @Override
+                            public boolean itemSelectable(Item item) {
+                                return item instanceof Armor;
+                            }
+
+                            @Override
+                            public void onSelect(Item item) {
+                                if (!(item instanceof Armor)) {
+                                    // do nothing, should only happen when window is cancelled
+                                } else if (item.unique || ((Armor) item).checkSeal() != null) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_unique"));
+                                    hide();
+                                } else if (!item.isIdentified()) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_unidentified"));
+                                    hide();
+                                } else if (item.cursed) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_cursed"));
+                                    hide();
+                                } else if (((Armor) item).STRReq() > rose.ghostStrength()) {
+                                    GLog.w(Messages.get(WndGhostHero.class, "cant_strength"));
+                                    hide();
+                                } else {
+                                    if (item.isEquipped(Dungeon.hero)) {
+                                        ((Armor) item).doUnequip(Dungeon.hero, false, false);
+                                    } else {
+                                        item.detach(Dungeon.hero.belongings.backpack);
+                                    }
+                                    rose.armor = (Armor) item;
+                                    item(rose.armor);
+                                }
+
+                            }
+                        });
+                    }
+                }
+            };
+            btnArmor.setRect(btnWeapon.right() + BTN_GAP, btnWeapon.top(), BTN_SIZE, BTN_SIZE);
+            if (rose.armor != null) {
+                btnArmor.item(rose.armor);
+            } else {
+                btnArmor.item(new WndBag.Placeholder(ItemSpriteSheet.ARMOR_HOLDER));
+            }
+            add(btnArmor);
+
+            resize(WIDTH, (int) (btnArmor.bottom() + GAP));
+        }
+
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/TimekeepersHourglass.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/TimekeepersHourglass.java
@@ -54,453 +54,464 @@ import java.util.ArrayList;
 
 public class TimekeepersHourglass extends Artifact {
 
-	{
-		image = ItemSpriteSheet.ARTIFACT_HOURGLASS;
-
-		levelCap = 5;
-
-		charge = 5+level();
-		partialCharge = 0;
-		chargeCap = 5+level();
-
-		defaultAction = AC_ACTIVATE;
-	}
-
-	public static final String AC_ACTIVATE = "ACTIVATE";
-
-	//keeps track of generated sandbags.
-	public int sandBags = 0;
-
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		if (isEquipped( hero )
-				&& !cursed
-				&& hero.buff(MagicImmune.class) == null
-				&& (charge > 0 || activeBuff != null)) {
-			actions.add(AC_ACTIVATE);
-		}
-		return actions;
-	}
-
-	@Override
-	public void execute( Hero hero, String action ) {
-
-		super.execute(hero, action);
-
-		if (hero.buff(MagicImmune.class) != null) return;
-
-		if (action.equals(AC_ACTIVATE)){
-
-			if (!isEquipped( hero ))        GLog.i( Messages.get(Artifact.class, "need_to_equip") );
-			else if (activeBuff != null) {
-				if (activeBuff instanceof timeStasis) { //do nothing
-				} else {
-					activeBuff.detach();
-					GLog.i( Messages.get(this, "deactivate") );
-				}
-			} else if (charge <= 0)         GLog.i( Messages.get(this, "no_charge") );
-			else if (cursed)                GLog.i( Messages.get(this, "cursed") );
-			else GameScene.show(
-						new WndOptions(new ItemSprite(this),
-								Messages.titleCase(name()),
-								Messages.get(this, "prompt"),
-								Messages.get(this, "stasis"),
-								Messages.get(this, "freeze")) {
-							@Override
-							protected void onSelect(int index) {
-								if (index == 0) {
-									GLog.i( Messages.get(TimekeepersHourglass.class, "onstasis") );
-									GameScene.flash(0x80FFFFFF);
-									Sample.INSTANCE.play(Assets.Sounds.TELEPORT);
-
-									activeBuff = new timeStasis();
-									Talent.onArtifactUsed(Dungeon.hero);
-									activeBuff.attachTo(Dungeon.hero);
-								} else if (index == 1) {
-									GLog.i( Messages.get(TimekeepersHourglass.class, "onfreeze") );
-									GameScene.flash(0x80FFFFFF);
-									Sample.INSTANCE.play(Assets.Sounds.TELEPORT);
-
-									Invisibility.dispel(Dungeon.hero);
-									activeBuff = new timeFreeze();
-									Talent.onArtifactUsed(Dungeon.hero);
-									activeBuff.attachTo(Dungeon.hero);
-									charge--;
-									((timeFreeze)activeBuff).processTime(0f);
-								}
-							}
-						}
-				);
-		}
-	}
-
-	@Override
-	public void activate(Char ch) {
-		super.activate(ch);
-		if (activeBuff != null)
-			activeBuff.attachTo(ch);
-	}
-
-	@Override
-	public boolean doUnequip(Hero hero, boolean collect, boolean single) {
-		if (super.doUnequip(hero, collect, single)){
-			if (activeBuff != null){
-				activeBuff.detach();
-				activeBuff = null;
-			}
-			return true;
-		} else
-			return false;
-	}
-
-	@Override
-	protected ArtifactBuff passiveBuff() {
-		return new hourglassRecharge();
-	}
-	
-	@Override
-	public void charge(Hero target, float amount) {
-		if (charge < chargeCap && !cursed && target.buff(MagicImmune.class) == null){
-			partialCharge += 0.25f*amount;
-			if (partialCharge >= 1){
-				partialCharge--;
-				charge++;
-				updateQuickslot();
-			}
-		}
-	}
-
-	@Override
-	public Item upgrade() {
-		chargeCap+= 1;
-
-		//for artifact transmutation.
-		while (level()+1 > sandBags)
-			sandBags ++;
-
-		return super.upgrade();
-	}
-
-	@Override
-	public String desc() {
-		String desc = super.desc();
-
-		if (isEquipped( Dungeon.hero )){
-			if (!cursed) {
-				if (level() < levelCap )
-					desc += "\n\n" + Messages.get(this, "desc_hint");
-
-			} else
-				desc += "\n\n" + Messages.get(this, "desc_cursed");
-		}
-		return desc;
-	}
-
-
-	private static final String SANDBAGS =  "sandbags";
-	private static final String BUFF =      "buff";
-
-	@Override
-	public void storeInBundle( Bundle bundle ) {
-		super.storeInBundle(bundle);
-		bundle.put( SANDBAGS, sandBags );
-
-		if (activeBuff != null)
-			bundle.put( BUFF , activeBuff );
-	}
-
-	@Override
-	public void restoreFromBundle( Bundle bundle ) {
-		super.restoreFromBundle(bundle);
-		sandBags = bundle.getInt( SANDBAGS );
-
-		//these buffs belong to hourglass, need to handle unbundling within the hourglass class.
-		if (bundle.contains( BUFF )){
-			Bundle buffBundle = bundle.getBundle( BUFF );
-
-			if (buffBundle.contains( timeFreeze.PRESSES ))
-				activeBuff = new timeFreeze();
-			else
-				activeBuff = new timeStasis();
-
-			activeBuff.restoreFromBundle(buffBundle);
-		}
-	}
-
-	public class hourglassRecharge extends ArtifactBuff {
-		@Override
-		public boolean act() {
-
-			if (charge < chargeCap
-					&& !cursed
-					&& target.buff(MagicImmune.class) == null
-					&& Regeneration.regenOn()) {
-				//90 turns to charge at full, 60 turns to charge at 0/10
-				float chargeGain = 1 / (90f - (chargeCap - charge)*3f);
-				chargeGain *= RingOfEnergy.artifactChargeMultiplier(target);
-				partialCharge += chargeGain;
-
-				if (partialCharge >= 1) {
-					partialCharge --;
-					charge ++;
-
-					if (charge == chargeCap){
-						partialCharge = 0;
-					}
-				}
-			} else if (cursed && Random.Int(10) == 0)
-				((Hero) target).spend( TICK );
-
-			updateQuickslot();
-
-			spend( TICK );
-
-			return true;
-		}
-	}
-
-	public class timeStasis extends ArtifactBuff {
-		
-		{
-			type = buffType.POSITIVE;
-			actPriority = BUFF_PRIO-3; //acts after all other buffs, so they are prevented
-		}
-
-		@Override
-		public boolean attachTo(Char target) {
-
-			if (super.attachTo(target)) {
-
-				Invisibility.dispel();
-
-				int usedCharge = Math.min(charge, 2);
-				//buffs always act last, so the stasis buff should end a turn early.
-				spend(5*usedCharge);
-
-				//shouldn't punish the player for going into stasis frequently
-				Hunger hunger = Buff.affect(target, Hunger.class);
-				if (hunger != null && !hunger.isStarving()) {
-					hunger.satisfy(5 * usedCharge);
-				}
-
-				charge -= usedCharge;
-
-				target.invisible++;
-				target.paralysed++;
-				target.next();
-
-				updateQuickslot();
-
-				if (Dungeon.hero != null) {
-					Dungeon.observe();
-				}
-
-				return true;
-			} else {
-				return false;
-			}
-		}
-
-		@Override
-		public boolean act() {
-			detach();
-			return true;
-		}
-
-		@Override
-		public void detach() {
-			if (target.invisible > 0) target.invisible--;
-			if (target.paralysed > 0) target.paralysed--;
-			super.detach();
-			activeBuff = null;
-			Dungeon.observe();
-		}
-
-		@Override
-		public void fx(boolean on) {
-			if (on) target.sprite.add( CharSprite.State.INVISIBLE );
-			else if (target.invisible == 0) target.sprite.remove( CharSprite.State.INVISIBLE );
-		}
-	}
-
-	public class timeFreeze extends ArtifactBuff {
-		
-		{
-			type = buffType.POSITIVE;
-		}
-
-		float turnsToCost = 2f;
-
-		ArrayList<Integer> presses = new ArrayList<>();
-
-		public void processTime(float time){
-			turnsToCost -= time;
-
-			//use 1/1,000 to account for rounding errors
-			while (turnsToCost < -0.001f){
-				turnsToCost += 2f;
-				charge --;
-			}
-
-			updateQuickslot();
-
-			if (charge < 0 || charge == 0 && turnsToCost <= 0){
-				charge = 0;
-				detach();
-			}
-
-		}
-
-		public void setDelayedPress(int cell){
-			if (!presses.contains(cell))
-				presses.add(cell);
-		}
-
-		public void triggerPresses(){
-			for (int cell : presses){
-				Trap t = Dungeon.level.traps.get(cell);
-				if (t != null){
-					t.trigger();
-				}
-				Plant p = Dungeon.level.plants.get(cell);
-				if (p != null){
-					p.trigger();
-				}
-			}
-
-			presses = new ArrayList<>();
-		}
-
-		public void disarmPresses(){
-			for (int cell : presses){
-				Trap t = Dungeon.level.traps.get(cell);
-				if (t != null && t.disarmedByActivation) {
-					t.disarm();
-				}
-
-				Dungeon.level.uproot(cell);
-			}
-
-			presses = new ArrayList<>();
-		}
-
-		@Override
-		public void detach(){
-			updateQuickslot();
-			super.detach();
-			activeBuff = null;
-			triggerPresses();
-			target.next();
-		}
-
-		@Override
-		public void fx(boolean on) {
-			if (!(target instanceof Hero)) return;
-			Emitter.freezeEmitters = on;
-			if (on){
-				for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
-					if (mob.sprite != null) mob.sprite.add(CharSprite.State.PARALYSED);
-				}
-			} else {
-				for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
-					if (mob.paralysed <= 0) mob.sprite.remove(CharSprite.State.PARALYSED);
-				}
-			}
-		}
-
-		@Override
-		public int icon() {
-			return BuffIndicator.TIME;
-		}
-
-		@Override
-		public void tintIcon(Image icon) {
-			icon.hardlight(1f, 0.5f, 0);
-		}
-
-		@Override
-		public float iconFadePercent() {
-			return Math.max(0, (2f - turnsToCost) / 2f);
-		}
-
-		@Override
-		public String iconTextDisplay() {
-			return Integer.toString((int)turnsToCost);
-		}
-
-		@Override
-		public String desc() {
-			return Messages.get(this, "desc", Messages.decimalFormat("#.##", turnsToCost));
-		}
-
-		private static final String PRESSES = "presses";
-		private static final String TURNSTOCOST = "turnsToCost";
-
-		@Override
-		public void storeInBundle(Bundle bundle) {
-			super.storeInBundle(bundle);
-
-			int[] values = new int[presses.size()];
-			for (int i = 0; i < values.length; i ++)
-				values[i] = presses.get(i);
-			bundle.put( PRESSES , values );
-
-			bundle.put( TURNSTOCOST , turnsToCost);
-		}
-
-		@Override
-		public void restoreFromBundle(Bundle bundle) {
-			super.restoreFromBundle(bundle);
-
-			int[] values = bundle.getIntArray( PRESSES );
-			for (int value : values)
-				presses.add(value);
-
-			turnsToCost = bundle.getFloat( TURNSTOCOST );
-		}
-	}
-
-	public static class sandBag extends Item {
-
-		{
-			image = ItemSpriteSheet.SANDBAG;
-		}
-
-		@Override
-		public boolean doPickUp(Hero hero, int pos) {
-			TimekeepersHourglass hourglass = hero.belongings.getItem( TimekeepersHourglass.class );
-			if (hourglass != null && !hourglass.cursed) {
-				hourglass.upgrade();
-				Sample.INSTANCE.play( Assets.Sounds.DEWDROP );
-				if (hourglass.level() == hourglass.levelCap)
-					GLog.p( Messages.get(this, "maxlevel") );
-				else
-					GLog.i( Messages.get(this, "levelup") );
-				GameScene.pickUp(this, pos);
-				hero.spendAndNext(TIME_TO_PICK_UP);
-				return true;
-			} else {
-				GLog.w( Messages.get(this, "no_hourglass") );
-				return false;
-			}
-		}
-
-		@Override
-		public int value() {
-			return 30;
-		}
-
-		@Override
-		public boolean isUpgradable() {
-			return false;
-		}
-
-		@Override
-		public boolean isIdentified() {
-			return true;
-		}
-	}
-
+    {
+        image = ItemSpriteSheet.ARTIFACT_HOURGLASS;
+
+        levelCap = 5;
+
+        charge = 5 + level();
+        partialCharge = 0;
+        chargeCap = 5 + level();
+
+        defaultAction = AC_ACTIVATE;
+    }
+
+    public static final String AC_ACTIVATE = "ACTIVATE";
+
+    // keeps track of generated sandbags.
+    public int sandBags = 0;
+
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        if (isEquipped(hero)
+                && !cursed
+                && hero.buff(MagicImmune.class) == null
+                && (charge > 0 || activeBuff != null)) {
+            actions.add(AC_ACTIVATE);
+        }
+        return actions;
+    }
+
+    @Override
+    public void execute(Hero hero, String action) {
+
+        super.execute(hero, action);
+
+        if (hero.buff(MagicImmune.class) != null)
+            return;
+
+        if (action.equals(AC_ACTIVATE)) {
+
+            if (!isEquipped(hero))
+                GLog.i(Messages.get(Artifact.class, "need_to_equip"));
+            else if (activeBuff != null) {
+                if (activeBuff instanceof timeStasis) { // do nothing
+                } else {
+                    activeBuff.detach();
+                    GLog.i(Messages.get(this, "deactivate"));
+                }
+            } else if (charge <= 0)
+                GLog.i(Messages.get(this, "no_charge"));
+            else if (cursed)
+                GLog.i(Messages.get(this, "cursed"));
+            else
+                GameScene.show(
+                        new WndOptions(new ItemSprite(this),
+                                Messages.titleCase(name()),
+                                Messages.get(this, "prompt"),
+                                Messages.get(this, "stasis"),
+                                Messages.get(this, "freeze")) {
+                            @Override
+                            protected void onSelect(int index) {
+                                if (index == 0) {
+                                    GLog.i(Messages.get(TimekeepersHourglass.class, "onstasis"));
+                                    GameScene.flash(0x80FFFFFF);
+                                    Sample.INSTANCE.play(Assets.Sounds.TELEPORT);
+
+                                    activeBuff = new timeStasis();
+                                    Talent.onArtifactUsed(Dungeon.hero);
+                                    activeBuff.attachTo(Dungeon.hero);
+                                } else if (index == 1) {
+                                    GLog.i(Messages.get(TimekeepersHourglass.class, "onfreeze"));
+                                    GameScene.flash(0x80FFFFFF);
+                                    Sample.INSTANCE.play(Assets.Sounds.TELEPORT);
+
+                                    Invisibility.dispel(Dungeon.hero);
+                                    activeBuff = new timeFreeze();
+                                    Talent.onArtifactUsed(Dungeon.hero);
+                                    activeBuff.attachTo(Dungeon.hero);
+                                    charge--;
+                                    ((timeFreeze) activeBuff).processTime(0f);
+                                }
+                            }
+                        });
+        }
+    }
+
+    @Override
+    public void activate(Char ch) {
+        super.activate(ch);
+        if (activeBuff != null)
+            activeBuff.attachTo(ch);
+    }
+
+    @Override
+    public boolean doUnequip(Hero hero, boolean collect, boolean single) {
+        if (super.doUnequip(hero, collect, single)) {
+            if (activeBuff != null) {
+                activeBuff.detach();
+                activeBuff = null;
+            }
+            return true;
+        } else
+            return false;
+    }
+
+    @Override
+    protected ArtifactBuff passiveBuff() {
+        return new hourglassRecharge();
+    }
+
+    @Override
+    public void charge(Hero target, float amount) {
+        if (charge < chargeCap && !cursed && target.buff(MagicImmune.class) == null) {
+            partialCharge += 0.25f * amount;
+            if (partialCharge >= 1) {
+                partialCharge--;
+                charge++;
+                updateQuickslot();
+            }
+        }
+    }
+
+    @Override
+    public Item upgrade() {
+        chargeCap += 1;
+
+        // for artifact transmutation.
+        while (level() + 1 > sandBags)
+            sandBags++;
+
+        return super.upgrade();
+    }
+
+    @Override
+    public String desc() {
+        String desc = super.desc();
+
+        if (isEquipped(Dungeon.hero)) {
+            if (!cursed) {
+                if (level() < levelCap)
+                    desc += "\n\n" + Messages.get(this, "desc_hint");
+
+            } else
+                desc += "\n\n" + Messages.get(this, "desc_cursed");
+        }
+        return desc;
+    }
+
+    private static final String SANDBAGS = "sandbags";
+    private static final String BUFF = "buff";
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+        bundle.put(SANDBAGS, sandBags);
+
+        if (activeBuff != null)
+            bundle.put(BUFF, activeBuff);
+    }
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        super.restoreFromBundle(bundle);
+        sandBags = bundle.getInt(SANDBAGS);
+
+        // these buffs belong to hourglass, need to handle unbundling within the
+        // hourglass class.
+        if (bundle.contains(BUFF)) {
+            Bundle buffBundle = bundle.getBundle(BUFF);
+
+            if (buffBundle.contains(timeFreeze.PRESSES))
+                activeBuff = new timeFreeze();
+            else
+                activeBuff = new timeStasis();
+
+            activeBuff.restoreFromBundle(buffBundle);
+        }
+    }
+
+    public class hourglassRecharge extends ArtifactBuff {
+        @Override
+        public boolean act() {
+
+            if (charge < chargeCap
+                    && !cursed
+                    && target.buff(MagicImmune.class) == null
+                    && Regeneration.regenOn()) {
+                // 90 turns to charge at full, 60 turns to charge at 0/10
+                float chargeGain = 1 / (90f - (chargeCap - charge) * 3f);
+                chargeGain *= RingOfEnergy.artifactChargeMultiplier(target);
+                partialCharge += chargeGain;
+
+                if (partialCharge >= 1) {
+                    partialCharge--;
+                    charge++;
+
+                    if (charge == chargeCap) {
+                        partialCharge = 0;
+                    }
+                }
+            } else if (cursed && Random.Int(10) == 0)
+                ((Hero) target).spend(TICK);
+
+            updateQuickslot();
+
+            spend(TICK);
+
+            return true;
+        }
+    }
+
+    public class timeStasis extends ArtifactBuff {
+
+        {
+            type = buffType.POSITIVE;
+            actPriority = BUFF_PRIO - 3; // acts after all other buffs, so they are prevented
+        }
+
+        @Override
+        public boolean attachTo(Char target) {
+
+            if (super.attachTo(target)) {
+
+                Invisibility.dispel();
+
+                int usedCharge = Math.min(charge, 2);
+                // buffs always act last, so the stasis buff should end a turn early.
+                spend(5 * usedCharge);
+
+                // shouldn't punish the player for going into stasis frequently
+                Hunger hunger = Buff.affect(target, Hunger.class);
+                if (hunger != null && !hunger.isStarving()) {
+                    hunger.satisfy(5 * usedCharge);
+                }
+
+                charge -= usedCharge;
+
+                target.invisible++;
+                target.paralysed++;
+                target.next();
+
+                updateQuickslot();
+
+                if (Dungeon.hero != null) {
+                    Dungeon.observe();
+                }
+
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean act() {
+            detach();
+            return true;
+        }
+
+        @Override
+        public void detach() {
+            if (target.invisible > 0)
+                target.invisible--;
+            if (target.paralysed > 0)
+                target.paralysed--;
+            super.detach();
+            activeBuff = null;
+            Dungeon.observe();
+        }
+
+        @Override
+        public void fx(boolean on) {
+            if (on)
+                target.sprite.add(CharSprite.State.INVISIBLE);
+            else if (target.invisible == 0)
+                target.sprite.remove(CharSprite.State.INVISIBLE);
+        }
+    }
+
+    public class timeFreeze extends ArtifactBuff {
+
+        {
+            type = buffType.POSITIVE;
+        }
+
+        float turnsToCost = 2f;
+
+        ArrayList<Integer> presses = new ArrayList<>();
+
+        public void processTime(float time) {
+            turnsToCost -= time;
+
+            // use 1/1,000 to account for rounding errors
+            while (turnsToCost < -0.001f) {
+                turnsToCost += 2f;
+                charge--;
+            }
+
+            updateQuickslot();
+
+            if (charge < 0 || charge == 0 && turnsToCost <= 0) {
+                charge = 0;
+                detach();
+            }
+
+        }
+
+        public void setDelayedPress(int cell) {
+            if (!presses.contains(cell))
+                presses.add(cell);
+        }
+
+        public void triggerPresses() {
+            for (int cell : presses) {
+                Trap t = Dungeon.level.traps.get(cell);
+                if (t != null) {
+                    t.trigger();
+                }
+                Plant p = Dungeon.level.plants.get(cell);
+                if (p != null) {
+                    p.trigger();
+                }
+            }
+
+            presses = new ArrayList<>();
+        }
+
+        public void disarmPresses() {
+            for (int cell : presses) {
+                Trap t = Dungeon.level.traps.get(cell);
+                if (t != null && t.disarmedByActivation) {
+                    t.disarm();
+                }
+
+                Dungeon.level.uproot(cell);
+            }
+
+            presses = new ArrayList<>();
+        }
+
+        @Override
+        public void detach() {
+            updateQuickslot();
+            super.detach();
+            activeBuff = null;
+            triggerPresses();
+            target.next();
+        }
+
+        @Override
+        public void fx(boolean on) {
+            if (!(target instanceof Hero))
+                return;
+            Emitter.freezeEmitters = on;
+            if (on) {
+                for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
+                    if (mob.sprite != null)
+                        mob.sprite.add(CharSprite.State.PARALYSED);
+                }
+            } else {
+                for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
+                    if (mob.paralysed <= 0)
+                        mob.sprite.remove(CharSprite.State.PARALYSED);
+                }
+            }
+        }
+
+        @Override
+        public int icon() {
+            return BuffIndicator.TIME;
+        }
+
+        @Override
+        public void tintIcon(Image icon) {
+            icon.hardlight(1f, 0.5f, 0);
+        }
+
+        @Override
+        public float iconFadePercent() {
+            return Math.max(0, (2f - turnsToCost) / 2f);
+        }
+
+        @Override
+        public String iconTextDisplay() {
+            return Integer.toString((int) turnsToCost);
+        }
+
+        @Override
+        public String desc() {
+            return Messages.get(this, "desc", Messages.decimalFormat("#.##", turnsToCost));
+        }
+
+        private static final String PRESSES = "presses";
+        private static final String TURNSTOCOST = "turnsToCost";
+
+        @Override
+        public void storeInBundle(Bundle bundle) {
+            super.storeInBundle(bundle);
+
+            int[] values = new int[presses.size()];
+            for (int i = 0; i < values.length; i++)
+                values[i] = presses.get(i);
+            bundle.put(PRESSES, values);
+
+            bundle.put(TURNSTOCOST, turnsToCost);
+        }
+
+        @Override
+        public void restoreFromBundle(Bundle bundle) {
+            super.restoreFromBundle(bundle);
+
+            int[] values = bundle.getIntArray(PRESSES);
+            for (int value : values)
+                presses.add(value);
+
+            turnsToCost = bundle.getFloat(TURNSTOCOST);
+        }
+    }
+
+    public static class sandBag extends Item {
+
+        {
+            image = ItemSpriteSheet.SANDBAG;
+        }
+
+        @Override
+        public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+            TimekeepersHourglass hourglass = hero.belongings.getItem(TimekeepersHourglass.class);
+            if (hourglass != null && !hourglass.cursed) {
+                hourglass.upgrade();
+                Sample.INSTANCE.play(Assets.Sounds.DEWDROP);
+                if (hourglass.level() == hourglass.levelCap)
+                    GLog.p(Messages.get(this, "maxlevel"));
+                else
+                    GLog.i(Messages.get(this, "levelup"));
+                GameScene.pickUp(this, pos);
+                if (!isAutoLoot)
+                    hero.spendAndNext(TIME_TO_PICK_UP);
+                return true;
+            } else {
+                GLog.w(Messages.get(this, "no_hourglass"));
+                return false;
+            }
+        }
+
+        @Override
+        public int value() {
+            return 30;
+        }
+
+        @Override
+        public boolean isUpgradable() {
+            return false;
+        }
+
+        @Override
+        public boolean isIdentified() {
+            return true;
+        }
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
@@ -62,368 +62,369 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 
 public class Bomb extends Item {
-	
-	{
-		image = ItemSpriteSheet.BOMB;
 
-		defaultAction = AC_LIGHTTHROW;
-		usesTargeting = true;
+    {
+        image = ItemSpriteSheet.BOMB;
 
-		stackable = true;
-	}
+        defaultAction = AC_LIGHTTHROW;
+        usesTargeting = true;
 
-	public Fuse fuse;
+        stackable = true;
+    }
 
-	//FIXME using a static variable for this is kinda gross, should be a better way
-	private static boolean lightingFuse = false;
+    public Fuse fuse;
 
-	private static final String AC_LIGHTTHROW = "LIGHTTHROW";
+    // FIXME using a static variable for this is kinda gross, should be a better way
+    private static boolean lightingFuse = false;
 
-	@Override
-	public boolean isSimilar(Item item) {
-		return super.isSimilar(item) && this.fuse == ((Bomb) item).fuse;
-	}
-	
-	public boolean explodesDestructively(){
-		return true;
-	}
+    private static final String AC_LIGHTTHROW = "LIGHTTHROW";
 
-	@Override
-	public ArrayList<String> actions(Hero hero) {
-		ArrayList<String> actions = super.actions( hero );
-		actions.add ( AC_LIGHTTHROW );
-		return actions;
-	}
+    @Override
+    public boolean isSimilar(Item item) {
+        return super.isSimilar(item) && this.fuse == ((Bomb) item).fuse;
+    }
 
-	@Override
-	public void execute(Hero hero, String action) {
+    public boolean explodesDestructively() {
+        return true;
+    }
 
-		if (action.equals(AC_LIGHTTHROW)) {
-			lightingFuse = true;
-			action = AC_THROW;
-		} else
-			lightingFuse = false;
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        actions.add(AC_LIGHTTHROW);
+        return actions;
+    }
 
-		super.execute(hero, action);
-	}
+    @Override
+    public void execute(Hero hero, String action) {
 
-	@Override
-	protected void onThrow( int cell ) {
-		if (!Dungeon.level.pit[ cell ] && lightingFuse) {
-			Actor.addDelayed(fuse = new Fuse().ignite(this), 2);
-		}
-		if (Actor.findChar( cell ) != null && !(Actor.findChar( cell ) instanceof Hero) ){
-			ArrayList<Integer> candidates = new ArrayList<>();
-			for (int i : PathFinder.NEIGHBOURS8)
-				if (Dungeon.level.passable[cell + i])
-					candidates.add(cell + i);
-			int newCell = candidates.isEmpty() ? cell : Random.element(candidates);
-			Dungeon.level.drop( this, newCell ).sprite.drop( cell );
-		} else
-			super.onThrow( cell );
-	}
+        if (action.equals(AC_LIGHTTHROW)) {
+            lightingFuse = true;
+            action = AC_THROW;
+        } else
+            lightingFuse = false;
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (fuse != null) {
-			GLog.w( Messages.get(this, "snuff_fuse") );
-			fuse = null;
-		}
-		return super.doPickUp(hero, pos);
-	}
+        super.execute(hero, action);
+    }
 
-	public void explode(int cell){
-		//We're blowing up, so no need for a fuse anymore.
-		this.fuse = null;
+    @Override
+    protected void onThrow(int cell) {
+        if (!Dungeon.level.pit[cell] && lightingFuse) {
+            Actor.addDelayed(fuse = new Fuse().ignite(this), 2);
+        }
+        if (Actor.findChar(cell) != null && !(Actor.findChar(cell) instanceof Hero)) {
+            ArrayList<Integer> candidates = new ArrayList<>();
+            for (int i : PathFinder.NEIGHBOURS8)
+                if (Dungeon.level.passable[cell + i])
+                    candidates.add(cell + i);
+            int newCell = candidates.isEmpty() ? cell : Random.element(candidates);
+            Dungeon.level.drop(this, newCell).sprite.drop(cell);
+        } else
+            super.onThrow(cell);
+    }
 
-		Sample.INSTANCE.play( Assets.Sounds.BLAST );
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (fuse != null) {
+            GLog.w(Messages.get(this, "snuff_fuse"));
+            fuse = null;
+        }
+        return super.doPickUp(hero, pos, isAutoLoot);
+    }
 
-		if (explodesDestructively()) {
-			
-			ArrayList<Char> affected = new ArrayList<>();
-			
-			if (Dungeon.level.heroFOV[cell]) {
-				CellEmitter.center(cell).burst(BlastParticle.FACTORY, 30);
-			}
-			
-			boolean terrainAffected = false;
-			for (int n : PathFinder.NEIGHBOURS9) {
-				int c = cell + n;
-				if (c >= 0 && c < Dungeon.level.length()) {
-					if (Dungeon.level.heroFOV[c]) {
-						CellEmitter.get(c).burst(SmokeParticle.FACTORY, 4);
-					}
-					
-					if (Dungeon.level.flamable[c]) {
-						Dungeon.level.destroy(c);
-						GameScene.updateMap(c);
-						terrainAffected = true;
-					}
-					
-					//destroys items / triggers bombs caught in the blast.
-					Heap heap = Dungeon.level.heaps.get(c);
-					if (heap != null)
-						heap.explode();
-					
-					Char ch = Actor.findChar(c);
-					if (ch != null) {
-						affected.add(ch);
-					}
-				}
-			}
-			
-			for (Char ch : affected){
+    public void explode(int cell) {
+        // We're blowing up, so no need for a fuse anymore.
+        this.fuse = null;
 
-				//if they have already been killed by another bomb
-				if(!ch.isAlive()){
-					continue;
-				}
+        Sample.INSTANCE.play(Assets.Sounds.BLAST);
 
-				int dmg = Random.NormalIntRange(5 + Dungeon.scalingDepth(), 10 + Dungeon.scalingDepth()*2);
+        if (explodesDestructively()) {
 
-				//those not at the center of the blast take less damage
-				if (ch.pos != cell){
-					dmg = Math.round(dmg*0.67f);
-				}
+            ArrayList<Char> affected = new ArrayList<>();
 
-				dmg -= ch.drRoll();
+            if (Dungeon.level.heroFOV[cell]) {
+                CellEmitter.center(cell).burst(BlastParticle.FACTORY, 30);
+            }
 
-				if (dmg > 0) {
-					ch.damage(dmg, this);
-				}
-				
-				if (ch == Dungeon.hero && !ch.isAlive()) {
-					if (this instanceof MagicalBomb){
-						Badges.validateDeathFromFriendlyMagic();
-					}
-					GLog.n(Messages.get(this, "ondeath"));
-					Dungeon.fail(this);
-				}
-			}
-			
-			if (terrainAffected) {
-				Dungeon.observe();
-			}
-		}
-	}
-	
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	@Override
-	public Item random() {
-		switch(Random.Int( 4 )){
-			case 0:
-				return new DoubleBomb();
-			default:
-				return this;
-		}
-	}
+            boolean terrainAffected = false;
+            for (int n : PathFinder.NEIGHBOURS9) {
+                int c = cell + n;
+                if (c >= 0 && c < Dungeon.level.length()) {
+                    if (Dungeon.level.heroFOV[c]) {
+                        CellEmitter.get(c).burst(SmokeParticle.FACTORY, 4);
+                    }
 
-	@Override
-	public ItemSprite.Glowing glowing() {
-		return fuse != null ? new ItemSprite.Glowing( 0xFF0000, 0.6f) : null;
-	}
+                    if (Dungeon.level.flamable[c]) {
+                        Dungeon.level.destroy(c);
+                        GameScene.updateMap(c);
+                        terrainAffected = true;
+                    }
 
-	@Override
-	public int value() {
-		return 20 * quantity;
-	}
-	
-	@Override
-	public String desc() {
-		if (fuse == null)
-			return super.desc()+ "\n\n" + Messages.get(this, "desc_fuse");
-		else
-			return super.desc() + "\n\n" + Messages.get(this, "desc_burning");
-	}
+                    // destroys items / triggers bombs caught in the blast.
+                    Heap heap = Dungeon.level.heaps.get(c);
+                    if (heap != null)
+                        heap.explode();
 
-	private static final String FUSE = "fuse";
+                    Char ch = Actor.findChar(c);
+                    if (ch != null) {
+                        affected.add(ch);
+                    }
+                }
+            }
 
-	@Override
-	public void storeInBundle(Bundle bundle) {
-		super.storeInBundle(bundle);
-		bundle.put( FUSE, fuse );
-	}
+            for (Char ch : affected) {
 
-	@Override
-	public void restoreFromBundle(Bundle bundle) {
-		super.restoreFromBundle(bundle);
-		if (bundle.contains( FUSE ))
-			Actor.add( fuse = ((Fuse)bundle.get(FUSE)).ignite(this) );
-	}
+                // if they have already been killed by another bomb
+                if (!ch.isAlive()) {
+                    continue;
+                }
 
-	//used to track the death from friendly magic badge
-	public static class MagicalBomb extends Bomb{};
+                int dmg = Random.NormalIntRange(5 + Dungeon.scalingDepth(), 10 + Dungeon.scalingDepth() * 2);
 
-	public static class Fuse extends Actor{
+                // those not at the center of the blast take less damage
+                if (ch.pos != cell) {
+                    dmg = Math.round(dmg * 0.67f);
+                }
 
-		{
-			actPriority = BLOB_PRIO+1; //after hero, before other actors
-		}
+                dmg -= ch.drRoll();
 
-		private Bomb bomb;
+                if (dmg > 0) {
+                    ch.damage(dmg, this);
+                }
 
-		public Fuse ignite(Bomb bomb){
-			this.bomb = bomb;
-			return this;
-		}
+                if (ch == Dungeon.hero && !ch.isAlive()) {
+                    if (this instanceof MagicalBomb) {
+                        Badges.validateDeathFromFriendlyMagic();
+                    }
+                    GLog.n(Messages.get(this, "ondeath"));
+                    Dungeon.fail(this);
+                }
+            }
 
-		@Override
-		protected boolean act() {
+            if (terrainAffected) {
+                Dungeon.observe();
+            }
+        }
+    }
 
-			//something caused our bomb to explode early, or be defused. Do nothing.
-			if (bomb.fuse != this){
-				Actor.remove( this );
-				return true;
-			}
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
 
-			//look for our bomb, remove it from its heap, and blow it up.
-			for (Heap heap : Dungeon.level.heaps.valueList()) {
-				if (heap.items.contains(bomb)) {
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
 
-					//FIXME this is a bit hacky, might want to generalize the functionality
-					//of bombs that don't explode instantly when their fuse ends
-					if (bomb instanceof Noisemaker){
+    @Override
+    public Item random() {
+        switch (Random.Int(4)) {
+            case 0:
+                return new DoubleBomb();
+            default:
+                return this;
+        }
+    }
 
-						((Noisemaker) bomb).setTrigger(heap.pos);
+    @Override
+    public ItemSprite.Glowing glowing() {
+        return fuse != null ? new ItemSprite.Glowing(0xFF0000, 0.6f) : null;
+    }
 
-					} else {
+    @Override
+    public int value() {
+        return 20 * quantity;
+    }
 
-						heap.remove(bomb);
+    @Override
+    public String desc() {
+        if (fuse == null)
+            return super.desc() + "\n\n" + Messages.get(this, "desc_fuse");
+        else
+            return super.desc() + "\n\n" + Messages.get(this, "desc_burning");
+    }
 
-						bomb.explode(heap.pos);
-					}
+    private static final String FUSE = "fuse";
 
-					diactivate();
-					Actor.remove(this);
-					return true;
-				}
-			}
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+        bundle.put(FUSE, fuse);
+    }
 
-			//can't find our bomb, something must have removed it, do nothing.
-			bomb.fuse = null;
-			Actor.remove( this );
-			return true;
-		}
-	}
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        super.restoreFromBundle(bundle);
+        if (bundle.contains(FUSE))
+            Actor.add(fuse = ((Fuse) bundle.get(FUSE)).ignite(this));
+    }
 
+    // used to track the death from friendly magic badge
+    public static class MagicalBomb extends Bomb {
+    };
 
-	public static class DoubleBomb extends Bomb{
+    public static class Fuse extends Actor {
 
-		{
-			image = ItemSpriteSheet.DBL_BOMB;
-			stackable = false;
-		}
+        {
+            actPriority = BLOB_PRIO + 1; // after hero, before other actors
+        }
 
-		@Override
-		public boolean doPickUp(Hero hero, int pos) {
-			Bomb bomb = new Bomb();
-			bomb.quantity(2);
-			if (bomb.doPickUp(hero, pos)) {
-				//isaaaaac.... (don't bother doing this when not in english)
-				if (SPDSettings.language() == Languages.ENGLISH)
-					hero.sprite.showStatus(CharSprite.NEUTRAL, "1+1 free!");
-				return true;
-			}
-			return false;
-		}
-	}
-	
-	public static class EnhanceBomb extends Recipe {
-		
-		public static final LinkedHashMap<Class<?extends Item>, Class<?extends Bomb>> validIngredients = new LinkedHashMap<>();
-		static {
-			validIngredients.put(PotionOfFrost.class,           FrostBomb.class);
-			validIngredients.put(ScrollOfMirrorImage.class,     WoollyBomb.class);
-			
-			validIngredients.put(PotionOfLiquidFlame.class,     Firebomb.class);
-			validIngredients.put(ScrollOfRage.class,            Noisemaker.class);
-			
-			validIngredients.put(PotionOfInvisibility.class,    Flashbang.class);
-			validIngredients.put(ScrollOfRecharging.class,      ShockBomb.class);
-			
-			validIngredients.put(PotionOfHealing.class,         RegrowthBomb.class);
-			validIngredients.put(ScrollOfRemoveCurse.class,     HolyBomb.class);
-			
-			validIngredients.put(GooBlob.class,                 ArcaneBomb.class);
-			validIngredients.put(MetalShard.class,              ShrapnelBomb.class);
-		}
-		
-		private static final HashMap<Class<?extends Bomb>, Integer> bombCosts = new HashMap<>();
-		static {
-			bombCosts.put(FrostBomb.class,      0);
-			bombCosts.put(WoollyBomb.class,     0);
-			
-			bombCosts.put(Firebomb.class,       1);
-			bombCosts.put(Noisemaker.class,     1);
-			
-			bombCosts.put(Flashbang.class,      2);
-			bombCosts.put(ShockBomb.class,      2);
+        private Bomb bomb;
 
-			bombCosts.put(RegrowthBomb.class,   3);
-			bombCosts.put(HolyBomb.class,       3);
-			
-			bombCosts.put(ArcaneBomb.class,     6);
-			bombCosts.put(ShrapnelBomb.class,   6);
-		}
-		
-		@Override
-		public boolean testIngredients(ArrayList<Item> ingredients) {
-			boolean bomb = false;
-			boolean ingredient = false;
-			
-			for (Item i : ingredients){
-				if (!i.isIdentified()) return false;
-				if (i.getClass().equals(Bomb.class)){
-					bomb = true;
-				} else if (validIngredients.containsKey(i.getClass())){
-					ingredient = true;
-				}
-			}
-			
-			return bomb && ingredient;
-		}
-		
-		@Override
-		public int cost(ArrayList<Item> ingredients) {
-			for (Item i : ingredients){
-				if (validIngredients.containsKey(i.getClass())){
-					return (bombCosts.get(validIngredients.get(i.getClass())));
-				}
-			}
-			return 0;
-		}
-		
-		@Override
-		public Item brew(ArrayList<Item> ingredients) {
-			Item result = null;
-			
-			for (Item i : ingredients){
-				i.quantity(i.quantity()-1);
-				if (validIngredients.containsKey(i.getClass())){
-					result = Reflection.newInstance(validIngredients.get(i.getClass()));
-				}
-			}
-			
-			return result;
-		}
-		
-		@Override
-		public Item sampleOutput(ArrayList<Item> ingredients) {
-			for (Item i : ingredients){
-				if (validIngredients.containsKey(i.getClass())){
-					return Reflection.newInstance(validIngredients.get(i.getClass()));
-				}
-			}
-			return null;
-		}
-	}
+        public Fuse ignite(Bomb bomb) {
+            this.bomb = bomb;
+            return this;
+        }
+
+        @Override
+        protected boolean act() {
+
+            // something caused our bomb to explode early, or be defused. Do nothing.
+            if (bomb.fuse != this) {
+                Actor.remove(this);
+                return true;
+            }
+
+            // look for our bomb, remove it from its heap, and blow it up.
+            for (Heap heap : Dungeon.level.heaps.valueList()) {
+                if (heap.items.contains(bomb)) {
+
+                    // FIXME this is a bit hacky, might want to generalize the functionality
+                    // of bombs that don't explode instantly when their fuse ends
+                    if (bomb instanceof Noisemaker) {
+
+                        ((Noisemaker) bomb).setTrigger(heap.pos);
+
+                    } else {
+
+                        heap.remove(bomb);
+
+                        bomb.explode(heap.pos);
+                    }
+
+                    diactivate();
+                    Actor.remove(this);
+                    return true;
+                }
+            }
+
+            // can't find our bomb, something must have removed it, do nothing.
+            bomb.fuse = null;
+            Actor.remove(this);
+            return true;
+        }
+    }
+
+    public static class DoubleBomb extends Bomb {
+
+        {
+            image = ItemSpriteSheet.DBL_BOMB;
+            stackable = false;
+        }
+
+        @Override
+        public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+            Bomb bomb = new Bomb();
+            bomb.quantity(2);
+            if (bomb.doPickUp(hero, pos, isAutoLoot)) {
+                // isaaaaac.... (don't bother doing this when not in english)
+                if (SPDSettings.language() == Languages.ENGLISH)
+                    hero.sprite.showStatus(CharSprite.NEUTRAL, "1+1 free!");
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public static class EnhanceBomb extends Recipe {
+
+        public static final LinkedHashMap<Class<? extends Item>, Class<? extends Bomb>> validIngredients = new LinkedHashMap<>();
+        static {
+            validIngredients.put(PotionOfFrost.class, FrostBomb.class);
+            validIngredients.put(ScrollOfMirrorImage.class, WoollyBomb.class);
+
+            validIngredients.put(PotionOfLiquidFlame.class, Firebomb.class);
+            validIngredients.put(ScrollOfRage.class, Noisemaker.class);
+
+            validIngredients.put(PotionOfInvisibility.class, Flashbang.class);
+            validIngredients.put(ScrollOfRecharging.class, ShockBomb.class);
+
+            validIngredients.put(PotionOfHealing.class, RegrowthBomb.class);
+            validIngredients.put(ScrollOfRemoveCurse.class, HolyBomb.class);
+
+            validIngredients.put(GooBlob.class, ArcaneBomb.class);
+            validIngredients.put(MetalShard.class, ShrapnelBomb.class);
+        }
+
+        private static final HashMap<Class<? extends Bomb>, Integer> bombCosts = new HashMap<>();
+        static {
+            bombCosts.put(FrostBomb.class, 0);
+            bombCosts.put(WoollyBomb.class, 0);
+
+            bombCosts.put(Firebomb.class, 1);
+            bombCosts.put(Noisemaker.class, 1);
+
+            bombCosts.put(Flashbang.class, 2);
+            bombCosts.put(ShockBomb.class, 2);
+
+            bombCosts.put(RegrowthBomb.class, 3);
+            bombCosts.put(HolyBomb.class, 3);
+
+            bombCosts.put(ArcaneBomb.class, 6);
+            bombCosts.put(ShrapnelBomb.class, 6);
+        }
+
+        @Override
+        public boolean testIngredients(ArrayList<Item> ingredients) {
+            boolean bomb = false;
+            boolean ingredient = false;
+
+            for (Item i : ingredients) {
+                if (!i.isIdentified())
+                    return false;
+                if (i.getClass().equals(Bomb.class)) {
+                    bomb = true;
+                } else if (validIngredients.containsKey(i.getClass())) {
+                    ingredient = true;
+                }
+            }
+
+            return bomb && ingredient;
+        }
+
+        @Override
+        public int cost(ArrayList<Item> ingredients) {
+            for (Item i : ingredients) {
+                if (validIngredients.containsKey(i.getClass())) {
+                    return (bombCosts.get(validIngredients.get(i.getClass())));
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public Item brew(ArrayList<Item> ingredients) {
+            Item result = null;
+
+            for (Item i : ingredients) {
+                i.quantity(i.quantity() - 1);
+                if (validIngredients.containsKey(i.getClass())) {
+                    result = Reflection.newInstance(validIngredients.get(i.getClass()));
+                }
+            }
+
+            return result;
+        }
+
+        @Override
+        public Item sampleOutput(ArrayList<Item> ingredients) {
+            for (Item i : ingredients) {
+                if (validIngredients.containsKey(i.getClass())) {
+                    return Reflection.newInstance(validIngredients.get(i.getClass()));
+                }
+            }
+            return null;
+        }
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Noisemaker.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Noisemaker.java
@@ -37,134 +37,135 @@ import com.watabou.noosa.audio.Sample;
 import com.watabou.utils.Bundle;
 
 public class Noisemaker extends Bomb {
-	
-	{
-		image = ItemSpriteSheet.NOISEMAKER;
-	}
 
-	public void setTrigger(int cell){
+    {
+        image = ItemSpriteSheet.NOISEMAKER;
+    }
 
-		Buff.affect(Dungeon.hero, Trigger.class).set(cell);
-		fuse = null;
+    public void setTrigger(int cell) {
 
-	}
+        Buff.affect(Dungeon.hero, Trigger.class).set(cell);
+        fuse = null;
 
-	@Override
-	public ItemSprite.Glowing glowing() {
-		if (fuse == null){
-			for (Trigger trigger : Dungeon.hero.buffs(Trigger.class)){
-				Heap heap = Dungeon.level.heaps.get(trigger.cell);
-				if (heap != null && heap.items.contains(this)) {
-					return new ItemSprite.Glowing( 0xFF0000, 0.6f);
-				}
-			}
-		}
-		return super.glowing();
-	}
+    }
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (fuse == null){
-			for (Trigger trigger : hero.buffs(Trigger.class)){
-				if (trigger.cell == pos) return false;
-			}
-		}
-		return super.doPickUp(hero, pos);
-	}
+    @Override
+    public ItemSprite.Glowing glowing() {
+        if (fuse == null) {
+            for (Trigger trigger : Dungeon.hero.buffs(Trigger.class)) {
+                Heap heap = Dungeon.level.heaps.get(trigger.cell);
+                if (heap != null && heap.items.contains(this)) {
+                    return new ItemSprite.Glowing(0xFF0000, 0.6f);
+                }
+            }
+        }
+        return super.glowing();
+    }
 
-	public static class Trigger extends Buff {
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (fuse == null) {
+            for (Trigger trigger : hero.buffs(Trigger.class)) {
+                if (trigger.cell == pos)
+                    return false;
+            }
+        }
+        return super.doPickUp(hero, pos, isAutoLoot);
+    }
 
-		{
-			revivePersists = true;
-		}
+    public static class Trigger extends Buff {
 
-		int cell;
-		int floor;
-		int left;
-		
-		public void set(int cell){
-			floor = Dungeon.depth;
-			this.cell = cell;
-			left = 0;
-		}
-		
-		@Override
-		public boolean act() {
+        {
+            revivePersists = true;
+        }
 
-			if (Dungeon.depth != floor){
-				spend(TICK);
-				return true;
-			}
+        int cell;
+        int floor;
+        int left;
 
-			Noisemaker bomb = null;
-			Heap heap = Dungeon.level.heaps.get(cell);
+        public void set(int cell) {
+            floor = Dungeon.depth;
+            this.cell = cell;
+            left = 0;
+        }
 
-			if (heap != null){
-				for (Item i : heap.items){
-					if (i instanceof Noisemaker){
-						bomb = (Noisemaker) i;
-						break;
-					}
-				}
-			}
+        @Override
+        public boolean act() {
 
-			if (bomb == null) {
-				detach();
+            if (Dungeon.depth != floor) {
+                spend(TICK);
+                return true;
+            }
 
-			} else if (Actor.findChar(cell) != null)  {
+            Noisemaker bomb = null;
+            Heap heap = Dungeon.level.heaps.get(cell);
 
-				heap.items.remove(bomb);
-				if (heap.items.isEmpty()) {
-					heap.destroy();
-				}
+            if (heap != null) {
+                for (Item i : heap.items) {
+                    if (i instanceof Noisemaker) {
+                        bomb = (Noisemaker) i;
+                        break;
+                    }
+                }
+            }
 
-				detach();
-				bomb.explode(cell);
+            if (bomb == null) {
+                detach();
 
-			} else {
-				spend(TICK);
+            } else if (Actor.findChar(cell) != null) {
 
-				left--;
+                heap.items.remove(bomb);
+                if (heap.items.isEmpty()) {
+                    heap.destroy();
+                }
 
-				if (left <= 0){
-					CellEmitter.center( cell ).start( Speck.factory( Speck.SCREAM ), 0.3f, 3 );
-					Sample.INSTANCE.play( Assets.Sounds.ALERT );
+                detach();
+                bomb.explode(cell);
 
-					for (Mob mob : Dungeon.level.mobs.toArray( new Mob[0] )) {
-						mob.beckon( cell );
-					}
-					left = 6;
-				}
+            } else {
+                spend(TICK);
 
-			}
+                left--;
 
-			return true;
-		}
+                if (left <= 0) {
+                    CellEmitter.center(cell).start(Speck.factory(Speck.SCREAM), 0.3f, 3);
+                    Sample.INSTANCE.play(Assets.Sounds.ALERT);
 
-		private static final String CELL = "cell";
-		private static final String FLOOR = "floor";
-		private static final String LEFT = "left";
+                    for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
+                        mob.beckon(cell);
+                    }
+                    left = 6;
+                }
 
-		@Override
-		public void storeInBundle(Bundle bundle) {
-			super.storeInBundle(bundle);
-			bundle.put(CELL, cell);
-			bundle.put(FLOOR, floor);
-			bundle.put(LEFT, left);
-		}
-		
-		@Override
-		public void restoreFromBundle(Bundle bundle) {
-			super.restoreFromBundle(bundle);
-			cell = bundle.getInt(CELL);
-			floor = bundle.getInt(FLOOR);
-			left = bundle.getInt(LEFT);
-		}
-	}
-	
-	@Override
-	public int value() {
-		//prices of ingredients
-		return quantity * (20 + 40);
-	}
+            }
+
+            return true;
+        }
+
+        private static final String CELL = "cell";
+        private static final String FLOOR = "floor";
+        private static final String LEFT = "left";
+
+        @Override
+        public void storeInBundle(Bundle bundle) {
+            super.storeInBundle(bundle);
+            bundle.put(CELL, cell);
+            bundle.put(FLOOR, floor);
+            bundle.put(LEFT, left);
+        }
+
+        @Override
+        public void restoreFromBundle(Bundle bundle) {
+            super.restoreFromBundle(bundle);
+            cell = bundle.getInt(CELL);
+            floor = bundle.getInt(FLOOR);
+            left = bundle.getInt(LEFT);
+        }
+    }
+
+    @Override
+    public int value() {
+        // prices of ingredients
+        return quantity * (20 + 40);
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/Berry.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/food/Berry.java
@@ -32,40 +32,44 @@ import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 
 public class Berry extends Food {
 
-	{
-		image = ItemSpriteSheet.BERRY;
-		energy = Hunger.HUNGRY/3f; //100 food value
+    {
+        image = ItemSpriteSheet.BERRY;
+        energy = Hunger.HUNGRY / 3f; // 100 food value
 
-		bones = false;
-	}
+        bones = false;
+    }
 
-	@Override
-	protected float eatingTime(){
-		if (Dungeon.hero.hasTalent(Talent.IRON_STOMACH)
-				|| Dungeon.hero.hasTalent(Talent.ENERGIZING_MEAL)
-				|| Dungeon.hero.hasTalent(Talent.MYSTICAL_MEAL)
-				|| Dungeon.hero.hasTalent(Talent.INVIGORATING_MEAL)
-				|| Dungeon.hero.hasTalent(Talent.FOCUSED_MEAL)){
-			return 0;
-		} else {
-			return 1;
-		}
-	}
+    @Override
+    protected float eatingTime() {
+        if (Dungeon.hero.hasTalent(Talent.IRON_STOMACH)
+                || Dungeon.hero.hasTalent(Talent.ENERGIZING_MEAL)
+                || Dungeon.hero.hasTalent(Talent.MYSTICAL_MEAL)
+                || Dungeon.hero.hasTalent(Talent.INVIGORATING_MEAL)
+                || Dungeon.hero.hasTalent(Talent.FOCUSED_MEAL)) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
 
-	@Override
-	protected void satisfy(Hero hero) {
-		super.satisfy(hero);
-		SeedCounter counter = Buff.count(hero, SeedCounter.class, 1);
-		if (counter.count() >= 2){
-			Dungeon.level.drop(Generator.randomUsingDefaults(Generator.Category.SEED), hero.pos).sprite.drop();
-			counter.detach();
-		}
-	}
+    @Override
+    protected void satisfy(Hero hero) {
+        super.satisfy(hero);
+        SeedCounter counter = Buff.count(hero, SeedCounter.class, 1);
+        if (counter.count() >= 2) {
+            Dungeon.level.drop(Generator.randomUsingDefaults(Generator.Category.SEED), hero.pos, true).sprite.drop();
+            counter.detach();
+        }
+    }
 
-	@Override
-	public int value() {
-		return 5 * quantity;
-	}
+    @Override
+    public int value() {
+        return 5 * quantity;
+    }
 
-	public static class SeedCounter extends CounterBuff{{revivePersists = true;}};
+    public static class SeedCounter extends CounterBuff {
+        {
+            revivePersists = true;
+        }
+    };
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/DocumentPage.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/DocumentPage.java
@@ -32,60 +32,61 @@ import com.watabou.noosa.audio.Sample;
 import com.watabou.utils.Bundle;
 
 public abstract class DocumentPage extends Item {
-	
-	{
-		image = ItemSpriteSheet.MASTERY;
-	}
 
-	public abstract Document document();
-	
-	private String page;
-	
-	public void page( String page ){
-		this.page = page;
-	}
-	
-	public String page(){
-		return page;
-	}
-	
-	@Override
-	public final boolean doPickUp(Hero hero, int pos) {
-		GameScene.pickUpJournal(this, pos);
-		GameScene.flashForDocument(document(), page());
-		if (document() == Document.ALCHEMY_GUIDE){
-			WndJournal.last_index = 1;
-			WndJournal.AlchemyTab.currentPageIdx = document().pageIdx(page());
-		} else {
-			WndJournal.last_index = 0;
-		}
-		document().findPage(page);
-		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
-		return true;
-	}
+    {
+        image = ItemSpriteSheet.MASTERY;
+    }
 
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
+    public abstract Document document();
 
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	private static final String PAGE = "page";
-	
-	@Override
-	public void storeInBundle(Bundle bundle) {
-		super.storeInBundle(bundle);
-		bundle.put( PAGE, page() );
-	}
-	
-	@Override
-	public void restoreFromBundle(Bundle bundle) {
-		super.restoreFromBundle(bundle);
-		page = bundle.getString( PAGE );
-	}
+    private String page;
+
+    public void page(String page) {
+        this.page = page;
+    }
+
+    public String page() {
+        return page;
+    }
+
+    @Override
+    public final boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        GameScene.pickUpJournal(this, pos);
+        GameScene.flashForDocument(document(), page());
+        if (document() == Document.ALCHEMY_GUIDE) {
+            WndJournal.last_index = 1;
+            WndJournal.AlchemyTab.currentPageIdx = document().pageIdx(page());
+        } else {
+            WndJournal.last_index = 0;
+        }
+        document().findPage(page);
+        Sample.INSTANCE.play(Assets.Sounds.ITEM);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
+        return true;
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    private static final String PAGE = "page";
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+        bundle.put(PAGE, page());
+    }
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        super.restoreFromBundle(bundle);
+        page = bundle.getString(PAGE);
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/Guidebook.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/journal/Guidebook.java
@@ -34,38 +34,39 @@ import com.watabou.noosa.audio.Sample;
 
 public class Guidebook extends Item {
 
-	{
-		image = ItemSpriteSheet.MASTERY;
-	}
+    {
+        image = ItemSpriteSheet.MASTERY;
+    }
 
-	@Override
-	public final boolean doPickUp(Hero hero, int pos) {
-		Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_INTRO);
-		Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_EXAMINING);
-		Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_SURPRISE_ATKS);
-		Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_IDING);
-		Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_FOOD);
-		Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_DIEING);
+    @Override
+    public final boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_INTRO);
+        Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_EXAMINING);
+        Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_SURPRISE_ATKS);
+        Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_IDING);
+        Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_FOOD);
+        Document.ADVENTURERS_GUIDE.findPage(Document.GUIDE_DIEING);
 
-		GameScene.pickUpJournal(this, pos);
-		//we do this here so the pickup message appears before the tutorial text
-		GameLog.wipe();
-		GLog.i( Messages.capitalize(Messages.get(Hero.class, "you_now_have", name())) );
-		GLog.p(Messages.get(GameScene.class, "tutorial_guidebook"));
-		GameScene.flashForDocument(Document.ADVENTURERS_GUIDE, Document.GUIDE_INTRO);
-		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
-		return true;
-	}
+        GameScene.pickUpJournal(this, pos);
+        // we do this here so the pickup message appears before the tutorial text
+        GameLog.wipe();
+        GLog.i(Messages.capitalize(Messages.get(Hero.class, "you_now_have", name())));
+        GLog.p(Messages.get(GameScene.class, "tutorial_guidebook"));
+        GameScene.flashForDocument(Document.ADVENTURERS_GUIDE, Document.GUIDE_INTRO);
+        Sample.INSTANCE.play(Assets.Sounds.ITEM);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
+        return true;
+    }
 
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
 
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/Key.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/Key.java
@@ -32,54 +32,56 @@ import com.watabou.utils.Bundle;
 
 public abstract class Key extends Item {
 
-	public static final float TIME_TO_UNLOCK = 1f;
-	
-	{
-		stackable = true;
-		unique = true;
-	}
+    public static final float TIME_TO_UNLOCK = 1f;
 
-	//TODO currently keys can only appear on branch = 0, add branch support here if that changes
-	public int depth;
-	
-	@Override
-	public boolean isSimilar( Item item ) {
-		return super.isSimilar(item) && ((Key)item).depth == depth;
-	}
+    {
+        stackable = true;
+        unique = true;
+    }
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		GameScene.pickUpJournal(this, pos);
-		WndJournal.last_index = 2;
-		Notes.add(this);
-		Sample.INSTANCE.play( Assets.Sounds.ITEM );
-		hero.spendAndNext( TIME_TO_PICK_UP );
-		GameScene.updateKeyDisplay();
-		return true;
-	}
+    // TODO currently keys can only appear on branch = 0, add branch support here if
+    // that changes
+    public int depth;
 
-	private static final String DEPTH = "depth";
-	
-	@Override
-	public void storeInBundle( Bundle bundle ) {
-		super.storeInBundle( bundle );
-		bundle.put( DEPTH, depth );
-	}
-	
-	@Override
-	public void restoreFromBundle( Bundle bundle ) {
-		super.restoreFromBundle( bundle );
-		depth = bundle.getInt( DEPTH );
-	}
-	
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
+    @Override
+    public boolean isSimilar(Item item) {
+        return super.isSimilar(item) && ((Key) item).depth == depth;
+    }
+
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        GameScene.pickUpJournal(this, pos);
+        WndJournal.last_index = 2;
+        Notes.add(this);
+        Sample.INSTANCE.play(Assets.Sounds.ITEM);
+        if (!isAutoLoot)
+            hero.spendAndNext(TIME_TO_PICK_UP);
+        GameScene.updateKeyDisplay();
+        return true;
+    }
+
+    private static final String DEPTH = "depth";
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+        bundle.put(DEPTH, depth);
+    }
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        super.restoreFromBundle(bundle);
+        depth = bundle.getInt(DEPTH);
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/SkeletonKey.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/keys/SkeletonKey.java
@@ -33,38 +33,38 @@ import com.watabou.utils.Callback;
 import java.io.IOException;
 
 public class SkeletonKey extends Key {
-	
-	{
-		image = ItemSpriteSheet.SKELETON_KEY;
-	}
-	
-	public SkeletonKey() {
-		this( 0 );
-	}
-	
-	public SkeletonKey( int depth ) {
-		super();
-		this.depth = depth;
-	}
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if(!SPDSettings.supportNagged()){
-			try {
-				Dungeon.saveAll();
-				Game.runOnRenderThread(new Callback() {
-					@Override
-					public void call() {
-						ShatteredPixelDungeon.scene().add(new WndSupportPrompt());
-					}
-				});
-			} catch (IOException e) {
-				ShatteredPixelDungeon.reportException(e);
-			}
-			
-		}
-		
-		return super.doPickUp(hero, pos);
-	}
+    {
+        image = ItemSpriteSheet.SKELETON_KEY;
+    }
+
+    public SkeletonKey() {
+        this(0);
+    }
+
+    public SkeletonKey(int depth) {
+        super();
+        this.depth = depth;
+    }
+
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (!SPDSettings.supportNagged()) {
+            try {
+                Dungeon.saveAll();
+                Game.runOnRenderThread(new Callback() {
+                    @Override
+                    public void call() {
+                        ShatteredPixelDungeon.scene().add(new WndSupportPrompt());
+                    }
+                });
+            } catch (IOException e) {
+                ShatteredPixelDungeon.reportException(e);
+            }
+
+        }
+
+        return super.doPickUp(hero, pos, isAutoLoot);
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CeremonialCandle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CeremonialCandle.java
@@ -43,155 +43,154 @@ import com.watabou.utils.Random;
 
 import java.util.ArrayList;
 
-
 public class CeremonialCandle extends Item {
 
-	//generated with the wandmaker quest
-	public static int ritualPos;
+    // generated with the wandmaker quest
+    public static int ritualPos;
 
-	{
-		image = ItemSpriteSheet.CANDLE;
+    {
+        image = ItemSpriteSheet.CANDLE;
 
-		defaultAction = AC_THROW;
+        defaultAction = AC_THROW;
 
-		unique = true;
-		stackable = true;
-	}
+        unique = true;
+        stackable = true;
+    }
 
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
 
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
 
-	@Override
-	public void doDrop(Hero hero) {
-		super.doDrop(hero);
-		aflame = false;
-		checkCandles();
-	}
+    @Override
+    public void doDrop(Hero hero) {
+        super.doDrop(hero);
+        aflame = false;
+        checkCandles();
+    }
 
-	@Override
-	protected void onThrow(int cell) {
-		super.onThrow(cell);
-		aflame = false;
-		checkCandles();
-	}
+    @Override
+    protected void onThrow(int cell) {
+        super.onThrow(cell);
+        aflame = false;
+        checkCandles();
+    }
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (super.doPickUp(hero, pos)){
-			aflame = false;
-			return true;
-		}
-		return false;
-	}
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (super.doPickUp(hero, pos, isAutoLoot)) {
+            aflame = false;
+            return true;
+        }
+        return false;
+    }
 
-	public boolean aflame = false;
+    public boolean aflame = false;
 
-	public static String AFLAME = "aflame";
+    public static String AFLAME = "aflame";
 
-	@Override
-	public void storeInBundle(Bundle bundle) {
-		super.storeInBundle(bundle);
-		bundle.put(AFLAME, aflame);
-	}
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+        bundle.put(AFLAME, aflame);
+    }
 
-	@Override
-	public void restoreFromBundle(Bundle bundle) {
-		super.restoreFromBundle(bundle);
-		aflame = bundle.getBoolean(AFLAME);
-	}
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        super.restoreFromBundle(bundle);
+        aflame = bundle.getBoolean(AFLAME);
+    }
 
-	@Override
-	public Emitter emitter() {
-		if (aflame) {
-			Emitter emitter = new Emitter();
-			emitter.pos(6, 0);
-			emitter.fillTarget = false;
-			emitter.pour(ElmoParticle.FACTORY, 0.25f);
-			return emitter;
-		}
-		return super.emitter();
-	}
+    @Override
+    public Emitter emitter() {
+        if (aflame) {
+            Emitter emitter = new Emitter();
+            emitter.pos(6, 0);
+            emitter.fillTarget = false;
+            emitter.pour(ElmoParticle.FACTORY, 0.25f);
+            return emitter;
+        }
+        return super.emitter();
+    }
 
-	private static void checkCandles(){
-		if (!(Dungeon.level instanceof RegularLevel)){
-			return;
-		}
+    private static void checkCandles() {
+        if (!(Dungeon.level instanceof RegularLevel)) {
+            return;
+        }
 
-		if (!(((RegularLevel) Dungeon.level).room(ritualPos) instanceof RitualSiteRoom)){
-			return;
-		}
+        if (!(((RegularLevel) Dungeon.level).room(ritualPos) instanceof RitualSiteRoom)) {
+            return;
+        }
 
-		Heap[] candleHeaps = new Heap[4];
+        Heap[] candleHeaps = new Heap[4];
 
-		candleHeaps[0] = Dungeon.level.heaps.get(ritualPos - Dungeon.level.width());
-		candleHeaps[1] = Dungeon.level.heaps.get(ritualPos + 1);
-		candleHeaps[2] = Dungeon.level.heaps.get(ritualPos + Dungeon.level.width());
-		candleHeaps[3] = Dungeon.level.heaps.get(ritualPos - 1);
+        candleHeaps[0] = Dungeon.level.heaps.get(ritualPos - Dungeon.level.width());
+        candleHeaps[1] = Dungeon.level.heaps.get(ritualPos + 1);
+        candleHeaps[2] = Dungeon.level.heaps.get(ritualPos + Dungeon.level.width());
+        candleHeaps[3] = Dungeon.level.heaps.get(ritualPos - 1);
 
-		boolean allCandles = true;
-		for (Heap h : candleHeaps){
-			if (h != null && h.type == Heap.Type.HEAP){
-				boolean foundCandle = false;
-				for (Item i : h.items){
-					if (i instanceof CeremonialCandle){
-						if (!((CeremonialCandle) i).aflame) {
-							((CeremonialCandle) i).aflame = true;
-							h.sprite.view(h).place(h.pos);
-						}
-						foundCandle = true;
-					}
-				}
-				if (!foundCandle){
-					allCandles = false;
-				}
-			} else {
-				allCandles = false;
-			}
-		}
+        boolean allCandles = true;
+        for (Heap h : candleHeaps) {
+            if (h != null && h.type == Heap.Type.HEAP) {
+                boolean foundCandle = false;
+                for (Item i : h.items) {
+                    if (i instanceof CeremonialCandle) {
+                        if (!((CeremonialCandle) i).aflame) {
+                            ((CeremonialCandle) i).aflame = true;
+                            h.sprite.view(h).place(h.pos);
+                        }
+                        foundCandle = true;
+                    }
+                }
+                if (!foundCandle) {
+                    allCandles = false;
+                }
+            } else {
+                allCandles = false;
+            }
+        }
 
-		if (allCandles){
+        if (allCandles) {
 
-			for (Heap h : candleHeaps) {
-				for (Item i : h.items.toArray(new Item[0])){
-					if (i instanceof CeremonialCandle){
-						h.remove(i);
-					}
-				}
-			}
-				
-			Elemental.NewbornFireElemental elemental = new Elemental.NewbornFireElemental();
-			Char ch = Actor.findChar( ritualPos );
-			if (ch != null) {
-				ArrayList<Integer> candidates = new ArrayList<>();
-				for (int n : PathFinder.NEIGHBOURS8) {
-					int cell = ritualPos + n;
-					if ((Dungeon.level.passable[cell] || Dungeon.level.avoid[cell]) && Actor.findChar( cell ) == null) {
-						candidates.add( cell );
-					}
-				}
-				if (candidates.size() > 0) {
-					elemental.pos = Random.element( candidates );
-				} else {
-					elemental.pos = ritualPos;
-				}
-			} else {
-				elemental.pos = ritualPos;
-			}
-			elemental.state = elemental.HUNTING;
-			GameScene.add(elemental, 1);
+            for (Heap h : candleHeaps) {
+                for (Item i : h.items.toArray(new Item[0])) {
+                    if (i instanceof CeremonialCandle) {
+                        h.remove(i);
+                    }
+                }
+            }
 
-			for (int i : PathFinder.NEIGHBOURS9){
-				CellEmitter.get(ritualPos+i).burst(ElmoParticle.FACTORY, 10);
-			}
-			Sample.INSTANCE.play(Assets.Sounds.BURNING);
-		}
+            Elemental.NewbornFireElemental elemental = new Elemental.NewbornFireElemental();
+            Char ch = Actor.findChar(ritualPos);
+            if (ch != null) {
+                ArrayList<Integer> candidates = new ArrayList<>();
+                for (int n : PathFinder.NEIGHBOURS8) {
+                    int cell = ritualPos + n;
+                    if ((Dungeon.level.passable[cell] || Dungeon.level.avoid[cell]) && Actor.findChar(cell) == null) {
+                        candidates.add(cell);
+                    }
+                }
+                if (candidates.size() > 0) {
+                    elemental.pos = Random.element(candidates);
+                } else {
+                    elemental.pos = ritualPos;
+                }
+            } else {
+                elemental.pos = ritualPos;
+            }
+            elemental.state = elemental.HUNTING;
+            GameScene.add(elemental, 1);
 
-	}
+            for (int i : PathFinder.NEIGHBOURS9) {
+                CellEmitter.get(ritualPos + i).burst(ElmoParticle.FACTORY, 10);
+            }
+            Sample.INSTANCE.play(Assets.Sounds.BURNING);
+        }
+
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CorpseDust.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/CorpseDust.java
@@ -39,117 +39,119 @@ import com.watabou.utils.Random;
 import java.util.ArrayList;
 
 public class CorpseDust extends Item {
-	
-	{
-		image = ItemSpriteSheet.DUST;
-		
-		cursed = true;
-		cursedKnown = true;
-		
-		unique = true;
-	}
 
-	@Override
-	public ArrayList<String> actions(Hero hero) {
-		return new ArrayList<>(); //yup, no dropping this one
-	}
+    {
+        image = ItemSpriteSheet.DUST;
 
-	@Override
-	public boolean isUpgradable() {
-		return false;
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
+        cursed = true;
+        cursedKnown = true;
 
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		if (super.doPickUp(hero, pos)){
-			GLog.n( Messages.get( this, "chill") );
-			Buff.affect(hero, DustGhostSpawner.class);
-			return true;
-		}
-		return false;
-	}
+        unique = true;
+    }
 
-	@Override
-	protected void onDetach() {
-		DustGhostSpawner spawner = Dungeon.hero.buff(DustGhostSpawner.class);
-		if (spawner != null){
-			spawner.dispel();
-		}
-	}
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        return new ArrayList<>(); // yup, no dropping this one
+    }
 
-	public static class DustGhostSpawner extends Buff {
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
 
-		int spawnPower = 0;
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
 
-		{
-			//not cleansed by reviving, but does check to ensure the dust is still present
-			revivePersists = true;
-		}
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        if (super.doPickUp(hero, pos, isAutoLoot)) {
+            GLog.n(Messages.get(this, "chill"));
+            Buff.affect(hero, DustGhostSpawner.class);
+            return true;
+        }
+        return false;
+    }
 
-		@Override
-		public boolean act() {
-			if (target instanceof Hero && ((Hero) target).belongings.getItem(CorpseDust.class) == null){
-				spawnPower = 0;
-				spend(TICK);
-				return true;
-			}
+    @Override
+    protected void onDetach() {
+        DustGhostSpawner spawner = Dungeon.hero.buff(DustGhostSpawner.class);
+        if (spawner != null) {
+            spawner.dispel();
+        }
+    }
 
-			spawnPower++;
-			int wraiths = 1; //we include the wraith we're trying to spawn
-			for (Mob mob : Dungeon.level.mobs){
-				if (mob instanceof Wraith){
-					wraiths++;
-				}
-			}
+    public static class DustGhostSpawner extends Buff {
 
-			int powerNeeded = Math.min(25, wraiths*wraiths);
+        int spawnPower = 0;
 
-			if (powerNeeded <= spawnPower){
-				spawnPower -= powerNeeded;
-				int pos = 0;
-				//FIXME this seems like old bad code (why not more checks at least?) but corpse dust may be balanced around it
-				int tries = 20;
-				do{
-					pos = Random.Int(Dungeon.level.length());
-					tries --;
-				} while (tries > 0 && (!Dungeon.level.heroFOV[pos] || Dungeon.level.solid[pos] || Actor.findChar( pos ) != null));
-				if (tries > 0) {
-					Wraith.spawnAt(pos, false);
-					Sample.INSTANCE.play(Assets.Sounds.CURSED);
-				}
-			}
+        {
+            // not cleansed by reviving, but does check to ensure the dust is still present
+            revivePersists = true;
+        }
 
-			spend(TICK);
-			return true;
-		}
+        @Override
+        public boolean act() {
+            if (target instanceof Hero && ((Hero) target).belongings.getItem(CorpseDust.class) == null) {
+                spawnPower = 0;
+                spend(TICK);
+                return true;
+            }
 
-		public void dispel(){
-			detach();
-			for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])){
-				if (mob instanceof Wraith){
-					mob.die(null);
-				}
-			}
-		}
+            spawnPower++;
+            int wraiths = 1; // we include the wraith we're trying to spawn
+            for (Mob mob : Dungeon.level.mobs) {
+                if (mob instanceof Wraith) {
+                    wraiths++;
+                }
+            }
 
-		private static String SPAWNPOWER = "spawnpower";
+            int powerNeeded = Math.min(25, wraiths * wraiths);
 
-		@Override
-		public void storeInBundle(Bundle bundle) {
-			super.storeInBundle(bundle);
-			bundle.put( SPAWNPOWER, spawnPower );
-		}
+            if (powerNeeded <= spawnPower) {
+                spawnPower -= powerNeeded;
+                int pos = 0;
+                // FIXME this seems like old bad code (why not more checks at least?) but corpse
+                // dust may be balanced around it
+                int tries = 20;
+                do {
+                    pos = Random.Int(Dungeon.level.length());
+                    tries--;
+                } while (tries > 0
+                        && (!Dungeon.level.heroFOV[pos] || Dungeon.level.solid[pos] || Actor.findChar(pos) != null));
+                if (tries > 0) {
+                    Wraith.spawnAt(pos, false);
+                    Sample.INSTANCE.play(Assets.Sounds.CURSED);
+                }
+            }
 
-		@Override
-		public void restoreFromBundle(Bundle bundle) {
-			super.restoreFromBundle(bundle);
-			spawnPower = bundle.getInt( SPAWNPOWER );
-		}
-	}
+            spend(TICK);
+            return true;
+        }
+
+        public void dispel() {
+            detach();
+            for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
+                if (mob instanceof Wraith) {
+                    mob.die(null);
+                }
+            }
+        }
+
+        private static String SPAWNPOWER = "spawnpower";
+
+        @Override
+        public void storeInBundle(Bundle bundle) {
+            super.storeInBundle(bundle);
+            bundle.put(SPAWNPOWER, spawnPower);
+        }
+
+        @Override
+        public void restoreFromBundle(Bundle bundle) {
+            super.restoreFromBundle(bundle);
+            spawnPower = bundle.getInt(SPAWNPOWER);
+        }
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/ScrollOfTransmutation.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/ScrollOfTransmutation.java
@@ -54,296 +54,299 @@ import com.shatteredpixel.shatteredpixeldungeon.utils.GLog;
 import com.watabou.utils.Reflection;
 
 public class ScrollOfTransmutation extends InventoryScroll {
-	
-	{
-		icon = ItemSpriteSheet.Icons.SCROLL_TRANSMUTE;
-		
-		bones = true;
-	}
 
-	@Override
-	protected boolean usableOnItem(Item item) {
-		return item instanceof MeleeWeapon ||
-				(item instanceof MissileWeapon && (!(item instanceof Dart) || item instanceof TippedDart)) ||
-				(item instanceof Potion && !(item instanceof Elixir || item instanceof Brew || item instanceof AlchemicalCatalyst)) ||
-				item instanceof Scroll ||
-				item instanceof Ring ||
-				item instanceof Wand ||
-				item instanceof Plant.Seed ||
-				item instanceof Runestone ||
-				item instanceof Artifact;
-	}
-	
-	@Override
-	protected void onItemSelected(Item item) {
-		
-		Item result = changeItem(item);
-		
-		if (result == null){
-			//This shouldn't ever trigger
-			GLog.n( Messages.get(this, "nothing") );
-			curItem.collect( curUser.belongings.backpack );
-		} else {
-			if (result != item) {
-				int slot = Dungeon.quickslot.getSlot(item);
-				if (item.isEquipped(Dungeon.hero)) {
-					item.cursed = false; //to allow it to be unequipped
-					if (item instanceof Artifact && result instanceof Ring){
-						//if we turned an equipped artifact into a ring, ring goes into inventory
-						((EquipableItem) item).doUnequip(Dungeon.hero, false);
-						if (!result.collect()){
-							Dungeon.level.drop(result, curUser.pos).sprite.drop();
-						}
-					} else if (item instanceof KindOfWeapon && Dungeon.hero.belongings.secondWep() == item){
-						((EquipableItem) item).doUnequip(Dungeon.hero, false);
-						((KindOfWeapon) result).equipSecondary(Dungeon.hero);
-					} else {
-						((EquipableItem) item).doUnequip(Dungeon.hero, false);
-						((EquipableItem) result).doEquip(Dungeon.hero);
-					}
-					Dungeon.hero.spend(-Dungeon.hero.cooldown()); //cancel equip/unequip time
-				} else {
-					item.detach(Dungeon.hero.belongings.backpack);
-					if (!result.collect()) {
-						Dungeon.level.drop(result, curUser.pos).sprite.drop();
-					} else if (Dungeon.hero.belongings.getSimilar(result) != null){
-						result = Dungeon.hero.belongings.getSimilar(result);
-					}
-				}
-				if (slot != -1
-						&& result.defaultAction() != null
-						&& !Dungeon.quickslot.isNonePlaceholder(slot)
-						&& Dungeon.hero.belongings.contains(result)){
-					Dungeon.quickslot.setSlot(slot, result);
-				}
-			}
-			if (result.isIdentified()){
-				Catalog.setSeen(result.getClass());
-			}
-			Transmuting.show(curUser, item, result);
-			curUser.sprite.emitter().start(Speck.factory(Speck.CHANGE), 0.2f, 10);
-			GLog.p( Messages.get(this, "morph") );
-		}
-		
-	}
+    {
+        icon = ItemSpriteSheet.Icons.SCROLL_TRANSMUTE;
 
-	public static Item changeItem( Item item ){
-		if (item instanceof MagesStaff) {
-			return changeStaff((MagesStaff) item);
-		}else if (item instanceof TippedDart){
-			return changeTippeDart( (TippedDart)item );
-		} else if (item instanceof MeleeWeapon || item instanceof MissileWeapon) {
-			return changeWeapon( (Weapon)item );
-		} else if (item instanceof Scroll) {
-			return changeScroll( (Scroll)item );
-		} else if (item instanceof Potion) {
-			return changePotion( (Potion)item );
-		} else if (item instanceof Ring) {
-			return changeRing( (Ring)item );
-		} else if (item instanceof Wand) {
-			return changeWand( (Wand)item );
-		} else if (item instanceof Plant.Seed) {
-			return changeSeed((Plant.Seed) item);
-		} else if (item instanceof Runestone) {
-			return changeStone((Runestone) item);
-		} else if (item instanceof Artifact) {
-			Artifact a = changeArtifact( (Artifact)item );
-			if (a == null){
-				//if no artifacts are left, generate a random +0 ring with shared ID/curse state
-				Item result = Generator.randomUsingDefaults(Generator.Category.RING);
-				result.levelKnown = item.levelKnown;
-				result.cursed = item.cursed;
-				result.cursedKnown = item.cursedKnown;
-				result.level(0);
-				return result;
-			} else {
-				return a;
-			}
-		} else {
-			return null;
-		}
-	}
-	
-	private static MagesStaff changeStaff( MagesStaff staff ){
-		Class<?extends Wand> wandClass = staff.wandClass();
-		
-		if (wandClass == null){
-			return null;
-		} else {
-			Wand n;
-			do {
-				n = (Wand) Generator.randomUsingDefaults(Generator.Category.WAND);
-			} while (Challenges.isItemBlocked(n) || n.getClass() == wandClass);
-			n.level(0);
-			n.identify();
-			staff.imbueWand(n, null);
-		}
-		
-		return staff;
-	}
+        bones = true;
+    }
 
-	private static TippedDart changeTippeDart( TippedDart dart ){
-		TippedDart n;
-		do {
-			n = TippedDart.randomTipped(1);
-		} while (n.getClass() == dart.getClass());
+    @Override
+    protected boolean usableOnItem(Item item) {
+        return item instanceof MeleeWeapon ||
+                (item instanceof MissileWeapon && (!(item instanceof Dart) || item instanceof TippedDart)) ||
+                (item instanceof Potion
+                        && !(item instanceof Elixir || item instanceof Brew || item instanceof AlchemicalCatalyst))
+                ||
+                item instanceof Scroll ||
+                item instanceof Ring ||
+                item instanceof Wand ||
+                item instanceof Plant.Seed ||
+                item instanceof Runestone ||
+                item instanceof Artifact;
+    }
 
-		return n;
-	}
-	
-	private static Weapon changeWeapon( Weapon w ) {
-		
-		Weapon n;
-		Generator.Category c;
-		if (w instanceof MeleeWeapon) {
-			c = Generator.wepTiers[((MeleeWeapon)w).tier - 1];
-		} else {
-			c = Generator.misTiers[((MissileWeapon)w).tier - 1];
-		}
-		
-		do {
-			n = (Weapon)Generator.randomUsingDefaults(c);
-		} while (Challenges.isItemBlocked(n) || n.getClass() == w.getClass());
+    @Override
+    protected void onItemSelected(Item item) {
 
-		n.level(0);
-		n.quantity(1);
-		int level = w.trueLevel();
-		if (level > 0) {
-			n.upgrade( level );
-		} else if (level < 0) {
-			n.degrade( -level );
-		}
-		
-		n.enchantment = w.enchantment;
-		n.curseInfusionBonus = w.curseInfusionBonus;
-		n.masteryPotionBonus = w.masteryPotionBonus;
-		n.levelKnown = w.levelKnown;
-		n.cursedKnown = w.cursedKnown;
-		n.cursed = w.cursed;
-		n.augment = w.augment;
-		
-		return n;
-		
-	}
-	
-	private static Ring changeRing( Ring r ) {
-		Ring n;
-		do {
-			n = (Ring)Generator.randomUsingDefaults( Generator.Category.RING );
-		} while (Challenges.isItemBlocked(n) || n.getClass() == r.getClass());
-		
-		n.level(0);
-		
-		int level = r.level();
-		if (level > 0) {
-			n.upgrade( level );
-		} else if (level < 0) {
-			n.degrade( -level );
-		}
-		
-		n.levelKnown = r.levelKnown;
-		n.cursedKnown = r.cursedKnown;
-		n.cursed = r.cursed;
-		
-		return n;
-	}
-	
-	private static Artifact changeArtifact( Artifact a ) {
-		Artifact n;
-		do {
-			n = Generator.randomArtifact();
-		} while ( n != null && (Challenges.isItemBlocked(n) || n.getClass() == a.getClass()));
-		
-		if (n != null){
+        Item result = changeItem(item);
 
-			if (a instanceof DriedRose){
-				if (((DriedRose) a).ghostWeapon() != null){
-					Dungeon.level.drop(((DriedRose) a).ghostWeapon(), Dungeon.hero.pos);
-				}
-				if (((DriedRose) a).ghostArmor() != null){
-					Dungeon.level.drop(((DriedRose) a).ghostArmor(), Dungeon.hero.pos);
-				}
-			}
+        if (result == null) {
+            // This shouldn't ever trigger
+            GLog.n(Messages.get(this, "nothing"));
+            curItem.collect(curUser.belongings.backpack);
+        } else {
+            if (result != item) {
+                int slot = Dungeon.quickslot.getSlot(item);
+                if (item.isEquipped(Dungeon.hero)) {
+                    item.cursed = false; // to allow it to be unequipped
+                    if (item instanceof Artifact && result instanceof Ring) {
+                        // if we turned an equipped artifact into a ring, ring goes into inventory
+                        ((EquipableItem) item).doUnequip(Dungeon.hero, false);
+                        if (!result.collect()) {
+                            Dungeon.level.drop(result, curUser.pos).sprite.drop();
+                        }
+                    } else if (item instanceof KindOfWeapon && Dungeon.hero.belongings.secondWep() == item) {
+                        ((EquipableItem) item).doUnequip(Dungeon.hero, false);
+                        ((KindOfWeapon) result).equipSecondary(Dungeon.hero);
+                    } else {
+                        ((EquipableItem) item).doUnequip(Dungeon.hero, false);
+                        ((EquipableItem) result).doEquip(Dungeon.hero);
+                    }
+                    Dungeon.hero.spend(-Dungeon.hero.cooldown()); // cancel equip/unequip time
+                } else {
+                    item.detach(Dungeon.hero.belongings.backpack);
+                    if (!result.collect()) {
+                        Dungeon.level.drop(result, curUser.pos).sprite.drop();
+                    } else if (Dungeon.hero.belongings.getSimilar(result) != null) {
+                        result = Dungeon.hero.belongings.getSimilar(result);
+                    }
+                }
+                if (slot != -1
+                        && result.defaultAction() != null
+                        && !Dungeon.quickslot.isNonePlaceholder(slot)
+                        && Dungeon.hero.belongings.contains(result)) {
+                    Dungeon.quickslot.setSlot(slot, result);
+                }
+            }
+            if (result.isIdentified()) {
+                Catalog.setSeen(result.getClass());
+            }
+            Transmuting.show(curUser, item, result);
+            curUser.sprite.emitter().start(Speck.factory(Speck.CHANGE), 0.2f, 10);
+            GLog.p(Messages.get(this, "morph"));
+        }
 
-			n.cursedKnown = a.cursedKnown;
-			n.cursed = a.cursed;
-			n.levelKnown = a.levelKnown;
-			n.transferUpgrade(a.visiblyUpgraded());
-			return n;
-		}
-		
-		return null;
-	}
-	
-	private static Wand changeWand( Wand w ) {
-		
-		Wand n;
-		do {
-			n = (Wand)Generator.random( Generator.Category.WAND );
-		} while ( Challenges.isItemBlocked(n) || n.getClass() == w.getClass());
-		
-		n.level( 0 );
-		int level = w.trueLevel();
-		n.upgrade( level );
+    }
 
-		n.levelKnown = w.levelKnown;
-		n.curChargeKnown = w.curChargeKnown;
-		n.cursedKnown = w.cursedKnown;
-		n.cursed = w.cursed;
-		n.curseInfusionBonus = w.curseInfusionBonus;
-		n.resinBonus = w.resinBonus;
+    public static Item changeItem(Item item) {
+        if (item instanceof MagesStaff) {
+            return changeStaff((MagesStaff) item);
+        } else if (item instanceof TippedDart) {
+            return changeTippeDart((TippedDart) item);
+        } else if (item instanceof MeleeWeapon || item instanceof MissileWeapon) {
+            return changeWeapon((Weapon) item);
+        } else if (item instanceof Scroll) {
+            return changeScroll((Scroll) item);
+        } else if (item instanceof Potion) {
+            return changePotion((Potion) item);
+        } else if (item instanceof Ring) {
+            return changeRing((Ring) item);
+        } else if (item instanceof Wand) {
+            return changeWand((Wand) item);
+        } else if (item instanceof Plant.Seed) {
+            return changeSeed((Plant.Seed) item);
+        } else if (item instanceof Runestone) {
+            return changeStone((Runestone) item);
+        } else if (item instanceof Artifact) {
+            Artifact a = changeArtifact((Artifact) item);
+            if (a == null) {
+                // if no artifacts are left, generate a random +0 ring with shared ID/curse
+                // state
+                Item result = Generator.randomUsingDefaults(Generator.Category.RING);
+                result.levelKnown = item.levelKnown;
+                result.cursed = item.cursed;
+                result.cursedKnown = item.cursedKnown;
+                result.level(0);
+                return result;
+            } else {
+                return a;
+            }
+        } else {
+            return null;
+        }
+    }
 
-		n.curCharges =  w.curCharges;
-		n.updateLevel();
-		
-		return n;
-	}
-	
-	private static Plant.Seed changeSeed( Plant.Seed s ) {
-		
-		Plant.Seed n;
-		
-		do {
-			n = (Plant.Seed)Generator.randomUsingDefaults( Generator.Category.SEED );
-		} while (n.getClass() == s.getClass());
-		
-		return n;
-	}
-	
-	private static Runestone changeStone( Runestone r ) {
-		
-		Runestone n;
-		
-		do {
-			n = (Runestone) Generator.randomUsingDefaults( Generator.Category.STONE );
-		} while (n.getClass() == r.getClass());
-		
-		return n;
-	}
-	
-	private static Scroll changeScroll( Scroll s ) {
-		if (s instanceof ExoticScroll) {
-			return Reflection.newInstance(ExoticScroll.exoToReg.get(s.getClass()));
-		} else {
-			return Reflection.newInstance(ExoticScroll.regToExo.get(s.getClass()));
-		}
-	}
-	
-	private static Potion changePotion( Potion p ) {
-		if	(p instanceof ExoticPotion) {
-			return Reflection.newInstance(ExoticPotion.exoToReg.get(p.getClass()));
-		} else {
-			return Reflection.newInstance(ExoticPotion.regToExo.get(p.getClass()));
-		}
-	}
-	
-	@Override
-	public int value() {
-		return isKnown() ? 50 * quantity : super.value();
-	}
+    private static MagesStaff changeStaff(MagesStaff staff) {
+        Class<? extends Wand> wandClass = staff.wandClass();
 
-	@Override
-	public int energyVal() {
-		return isKnown() ? 8 * quantity : super.energyVal();
-	}
+        if (wandClass == null) {
+            return null;
+        } else {
+            Wand n;
+            do {
+                n = (Wand) Generator.randomUsingDefaults(Generator.Category.WAND);
+            } while (Challenges.isItemBlocked(n) || n.getClass() == wandClass);
+            n.level(0);
+            n.identify();
+            staff.imbueWand(n, null);
+        }
+
+        return staff;
+    }
+
+    private static TippedDart changeTippeDart(TippedDart dart) {
+        TippedDart n;
+        do {
+            n = TippedDart.randomTipped(1);
+        } while (n.getClass() == dart.getClass());
+
+        return n;
+    }
+
+    private static Weapon changeWeapon(Weapon w) {
+
+        Weapon n;
+        Generator.Category c;
+        if (w instanceof MeleeWeapon) {
+            c = Generator.wepTiers[((MeleeWeapon) w).tier - 1];
+        } else {
+            c = Generator.misTiers[((MissileWeapon) w).tier - 1];
+        }
+
+        do {
+            n = (Weapon) Generator.randomUsingDefaults(c);
+        } while (Challenges.isItemBlocked(n) || n.getClass() == w.getClass());
+
+        n.level(0);
+        n.quantity(1);
+        int level = w.trueLevel();
+        if (level > 0) {
+            n.upgrade(level);
+        } else if (level < 0) {
+            n.degrade(-level);
+        }
+
+        n.enchantment = w.enchantment;
+        n.curseInfusionBonus = w.curseInfusionBonus;
+        n.masteryPotionBonus = w.masteryPotionBonus;
+        n.levelKnown = w.levelKnown;
+        n.cursedKnown = w.cursedKnown;
+        n.cursed = w.cursed;
+        n.augment = w.augment;
+
+        return n;
+
+    }
+
+    private static Ring changeRing(Ring r) {
+        Ring n;
+        do {
+            n = (Ring) Generator.randomUsingDefaults(Generator.Category.RING);
+        } while (Challenges.isItemBlocked(n) || n.getClass() == r.getClass());
+
+        n.level(0);
+
+        int level = r.level();
+        if (level > 0) {
+            n.upgrade(level);
+        } else if (level < 0) {
+            n.degrade(-level);
+        }
+
+        n.levelKnown = r.levelKnown;
+        n.cursedKnown = r.cursedKnown;
+        n.cursed = r.cursed;
+
+        return n;
+    }
+
+    private static Artifact changeArtifact(Artifact a) {
+        Artifact n;
+        do {
+            n = Generator.randomArtifact();
+        } while (n != null && (Challenges.isItemBlocked(n) || n.getClass() == a.getClass()));
+
+        if (n != null) {
+
+            if (a instanceof DriedRose) {
+                if (((DriedRose) a).ghostWeapon() != null) {
+                    Dungeon.level.drop(((DriedRose) a).ghostWeapon(), Dungeon.hero.pos, true);
+                }
+                if (((DriedRose) a).ghostArmor() != null) {
+                    Dungeon.level.drop(((DriedRose) a).ghostArmor(), Dungeon.hero.pos, true);
+                }
+            }
+
+            n.cursedKnown = a.cursedKnown;
+            n.cursed = a.cursed;
+            n.levelKnown = a.levelKnown;
+            n.transferUpgrade(a.visiblyUpgraded());
+            return n;
+        }
+
+        return null;
+    }
+
+    private static Wand changeWand(Wand w) {
+
+        Wand n;
+        do {
+            n = (Wand) Generator.random(Generator.Category.WAND);
+        } while (Challenges.isItemBlocked(n) || n.getClass() == w.getClass());
+
+        n.level(0);
+        int level = w.trueLevel();
+        n.upgrade(level);
+
+        n.levelKnown = w.levelKnown;
+        n.curChargeKnown = w.curChargeKnown;
+        n.cursedKnown = w.cursedKnown;
+        n.cursed = w.cursed;
+        n.curseInfusionBonus = w.curseInfusionBonus;
+        n.resinBonus = w.resinBonus;
+
+        n.curCharges = w.curCharges;
+        n.updateLevel();
+
+        return n;
+    }
+
+    private static Plant.Seed changeSeed(Plant.Seed s) {
+
+        Plant.Seed n;
+
+        do {
+            n = (Plant.Seed) Generator.randomUsingDefaults(Generator.Category.SEED);
+        } while (n.getClass() == s.getClass());
+
+        return n;
+    }
+
+    private static Runestone changeStone(Runestone r) {
+
+        Runestone n;
+
+        do {
+            n = (Runestone) Generator.randomUsingDefaults(Generator.Category.STONE);
+        } while (n.getClass() == r.getClass());
+
+        return n;
+    }
+
+    private static Scroll changeScroll(Scroll s) {
+        if (s instanceof ExoticScroll) {
+            return Reflection.newInstance(ExoticScroll.exoToReg.get(s.getClass()));
+        } else {
+            return Reflection.newInstance(ExoticScroll.regToExo.get(s.getClass()));
+        }
+    }
+
+    private static Potion changePotion(Potion p) {
+        if (p instanceof ExoticPotion) {
+            return Reflection.newInstance(ExoticPotion.exoToReg.get(p.getClass()));
+        } else {
+            return Reflection.newInstance(ExoticPotion.regToExo.get(p.getClass()));
+        }
+    }
+
+    @Override
+    public int value() {
+        return isKnown() ? 50 * quantity : super.value();
+    }
+
+    @Override
+    public int energyVal() {
+        return isKnown() ? 8 * quantity : super.energyVal();
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/CursedWand.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/CursedWand.java
@@ -80,373 +80,384 @@ import java.util.ArrayList;
 //helper class to contain all the cursed wand zapping logic, so the main wand class doesn't get huge.
 public class CursedWand {
 
-	private static float COMMON_CHANCE = 0.6f;
-	private static float UNCOMMON_CHANCE = 0.3f;
-	private static float RARE_CHANCE = 0.09f;
-	private static float VERY_RARE_CHANCE = 0.01f;
+    private static float COMMON_CHANCE = 0.6f;
+    private static float UNCOMMON_CHANCE = 0.3f;
+    private static float RARE_CHANCE = 0.09f;
+    private static float VERY_RARE_CHANCE = 0.01f;
 
-	public static void cursedZap(final Item origin, final Char user, final Ballistica bolt, final Callback afterZap){
+    public static void cursedZap(final Item origin, final Char user, final Ballistica bolt, final Callback afterZap) {
 
-		cursedFX(user, bolt, new Callback() {
-			@Override
-			public void call() {
-				if (cursedEffect(origin, user, bolt.collisionPos)){
-					if (afterZap != null) afterZap.call();
-				}
-			}
-		});
-	}
+        cursedFX(user, bolt, new Callback() {
+            @Override
+            public void call() {
+                if (cursedEffect(origin, user, bolt.collisionPos)) {
+                    if (afterZap != null)
+                        afterZap.call();
+                }
+            }
+        });
+    }
 
-	public static void tryForWandProc( Char target, Item origin ){
-		if (target != null && origin instanceof Wand){
-			Wand.wandProc(target, origin.buffedLvl(), 1);
-		}
-	}
+    public static void tryForWandProc(Char target, Item origin) {
+        if (target != null && origin instanceof Wand) {
+            Wand.wandProc(target, origin.buffedLvl(), 1);
+        }
+    }
 
-	public static boolean cursedEffect(final Item origin, final Char user, final Char target){
-		return cursedEffect(origin, user, target.pos);
-	}
+    public static boolean cursedEffect(final Item origin, final Char user, final Char target) {
+        return cursedEffect(origin, user, target.pos);
+    }
 
-	public static boolean cursedEffect(final Item origin, final Char user, final int targetPos){
-		switch (Random.chances(new float[]{COMMON_CHANCE, UNCOMMON_CHANCE, RARE_CHANCE, VERY_RARE_CHANCE})){
-			case 0: default:
-				return commonEffect(origin, user, targetPos);
-			case 1:
-				return uncommonEffect(origin, user, targetPos);
-			case 2:
-				return rareEffect(origin, user, targetPos);
-			case 3:
-				return veryRareEffect(origin, user, targetPos);
-		}
-	}
+    public static boolean cursedEffect(final Item origin, final Char user, final int targetPos) {
+        switch (Random.chances(new float[] { COMMON_CHANCE, UNCOMMON_CHANCE, RARE_CHANCE, VERY_RARE_CHANCE })) {
+            case 0:
+            default:
+                return commonEffect(origin, user, targetPos);
+            case 1:
+                return uncommonEffect(origin, user, targetPos);
+            case 2:
+                return rareEffect(origin, user, targetPos);
+            case 3:
+                return veryRareEffect(origin, user, targetPos);
+        }
+    }
 
-	private static boolean commonEffect(final Item origin, final Char user, final int targetPos){
-		switch(Random.Int(4)){
+    private static boolean commonEffect(final Item origin, final Char user, final int targetPos) {
+        switch (Random.Int(4)) {
 
-			//anti-entropy
-			case 0: default:
-				Char target = Actor.findChar(targetPos);
-				if (Random.Int(2) == 0) {
-					if (target != null) Buff.affect(target, Burning.class).reignite(target);
-					Buff.affect(user, Frost.class, Frost.DURATION);
-				} else {
-					Buff.affect(user, Burning.class).reignite(user);
-					if (target != null) Buff.affect(target, Frost.class, Frost.DURATION);
-				}
-				tryForWandProc(target, origin);
-				return true;
+            // anti-entropy
+            case 0:
+            default:
+                Char target = Actor.findChar(targetPos);
+                if (Random.Int(2) == 0) {
+                    if (target != null)
+                        Buff.affect(target, Burning.class).reignite(target);
+                    Buff.affect(user, Frost.class, Frost.DURATION);
+                } else {
+                    Buff.affect(user, Burning.class).reignite(user);
+                    if (target != null)
+                        Buff.affect(target, Frost.class, Frost.DURATION);
+                }
+                tryForWandProc(target, origin);
+                return true;
 
-			//spawns some regrowth
-			case 1:
-				GameScene.add( Blob.seed(targetPos, 30, Regrowth.class));
-				tryForWandProc(Actor.findChar(targetPos), origin);
-				return true;
+            // spawns some regrowth
+            case 1:
+                GameScene.add(Blob.seed(targetPos, 30, Regrowth.class));
+                tryForWandProc(Actor.findChar(targetPos), origin);
+                return true;
 
-			//random teleportation
-			case 2:
-				if(Random.Int(2) == 0) {
-					if (user != null && !user.properties().contains(Char.Property.IMMOVABLE)) {
-						ScrollOfTeleportation.teleportChar(user);
-					} else {
-						return cursedEffect(origin, user, targetPos);
-					}
-				} else {
-					Char ch = Actor.findChar( targetPos );
-					if (ch != null && !ch.properties().contains(Char.Property.IMMOVABLE)) {
-						ScrollOfTeleportation.teleportChar(ch);
-						tryForWandProc(ch, origin);
-					} else {
-						return cursedEffect(origin, user, targetPos);
-					}
-				}
-				return true;
+            // random teleportation
+            case 2:
+                if (Random.Int(2) == 0) {
+                    if (user != null && !user.properties().contains(Char.Property.IMMOVABLE)) {
+                        ScrollOfTeleportation.teleportChar(user);
+                    } else {
+                        return cursedEffect(origin, user, targetPos);
+                    }
+                } else {
+                    Char ch = Actor.findChar(targetPos);
+                    if (ch != null && !ch.properties().contains(Char.Property.IMMOVABLE)) {
+                        ScrollOfTeleportation.teleportChar(ch);
+                        tryForWandProc(ch, origin);
+                    } else {
+                        return cursedEffect(origin, user, targetPos);
+                    }
+                }
+                return true;
 
-			//random gas at location
-			case 3:
-				Sample.INSTANCE.play( Assets.Sounds.GAS );
-				tryForWandProc(Actor.findChar(targetPos), origin);
-				switch (Random.Int(3)) {
-					case 0: default:
-						GameScene.add( Blob.seed( targetPos, 800, ConfusionGas.class ) );
-						return true;
-					case 1:
-						GameScene.add( Blob.seed( targetPos, 500, ToxicGas.class ) );
-						return true;
-					case 2:
-						GameScene.add( Blob.seed( targetPos, 200, ParalyticGas.class ) );
-						return true;
-				}
-		}
+            // random gas at location
+            case 3:
+                Sample.INSTANCE.play(Assets.Sounds.GAS);
+                tryForWandProc(Actor.findChar(targetPos), origin);
+                switch (Random.Int(3)) {
+                    case 0:
+                    default:
+                        GameScene.add(Blob.seed(targetPos, 800, ConfusionGas.class));
+                        return true;
+                    case 1:
+                        GameScene.add(Blob.seed(targetPos, 500, ToxicGas.class));
+                        return true;
+                    case 2:
+                        GameScene.add(Blob.seed(targetPos, 200, ParalyticGas.class));
+                        return true;
+                }
+        }
 
-	}
+    }
 
-	private static boolean uncommonEffect(final Item origin, final Char user, final int targetPos){
-		switch(Random.Int(4)){
+    private static boolean uncommonEffect(final Item origin, final Char user, final int targetPos) {
+        switch (Random.Int(4)) {
 
-			//Random plant
-			case 0: default:
-				int pos = targetPos;
+            // Random plant
+            case 0:
+            default:
+                int pos = targetPos;
 
-				if (Dungeon.level.map[pos] != Terrain.ALCHEMY
-						&& !Dungeon.level.pit[pos]
-						&& Dungeon.level.traps.get(pos) == null
-						&& !Dungeon.isChallenged(Challenges.NO_HERBALISM)) {
-					Dungeon.level.plant((Plant.Seed) Generator.randomUsingDefaults(Generator.Category.SEED), pos);
-					tryForWandProc(Actor.findChar(pos), origin);
-				} else {
-					return cursedEffect(origin, user, targetPos);
-				}
+                if (Dungeon.level.map[pos] != Terrain.ALCHEMY
+                        && !Dungeon.level.pit[pos]
+                        && Dungeon.level.traps.get(pos) == null
+                        && !Dungeon.isChallenged(Challenges.NO_HERBALISM)) {
+                    Dungeon.level.plant((Plant.Seed) Generator.randomUsingDefaults(Generator.Category.SEED), pos);
+                    tryForWandProc(Actor.findChar(pos), origin);
+                } else {
+                    return cursedEffect(origin, user, targetPos);
+                }
 
-				return true;
+                return true;
 
-			//Health transfer
-			case 1:
-				final Char target = Actor.findChar( targetPos );
-				if (target != null) {
-					int damage = Dungeon.scalingDepth() * 2;
-					Char toHeal, toDamage;
+            // Health transfer
+            case 1:
+                final Char target = Actor.findChar(targetPos);
+                if (target != null) {
+                    int damage = Dungeon.scalingDepth() * 2;
+                    Char toHeal, toDamage;
 
-					if (Random.Int(2) == 0){
-						toHeal = user;
-						toDamage = target;
-					} else {
-						toHeal = target;
-						toDamage = user;
-					}
-					toHeal.HP = Math.min(toHeal.HT, toHeal.HP + damage);
-					toHeal.sprite.emitter().burst(Speck.factory(Speck.HEALING), 3);
-					toDamage.damage(damage, new CursedWand());
-					toDamage.sprite.emitter().start(ShadowParticle.UP, 0.05f, 10);
+                    if (Random.Int(2) == 0) {
+                        toHeal = user;
+                        toDamage = target;
+                    } else {
+                        toHeal = target;
+                        toDamage = user;
+                    }
+                    toHeal.HP = Math.min(toHeal.HT, toHeal.HP + damage);
+                    toHeal.sprite.emitter().burst(Speck.factory(Speck.HEALING), 3);
+                    toDamage.damage(damage, new CursedWand());
+                    toDamage.sprite.emitter().start(ShadowParticle.UP, 0.05f, 10);
 
-					if (toDamage == Dungeon.hero){
-						Sample.INSTANCE.play(Assets.Sounds.CURSED);
-						if (!toDamage.isAlive()) {
-							if (user == Dungeon.hero && origin != null) {
-								Badges.validateDeathFromFriendlyMagic();
-								Dungeon.fail( origin );
-								GLog.n( Messages.get( CursedWand.class, "ondeath", origin.name() ) );
-							} else {
-								Badges.validateDeathFromEnemyMagic();
-								Dungeon.fail( toHeal );
-							}
-						}
-					} else {
-						Sample.INSTANCE.play(Assets.Sounds.BURNING);
-					}
-					tryForWandProc(target, origin);
-				} else {
-					return cursedEffect(origin, user, targetPos);
-				}
-				return true;
+                    if (toDamage == Dungeon.hero) {
+                        Sample.INSTANCE.play(Assets.Sounds.CURSED);
+                        if (!toDamage.isAlive()) {
+                            if (user == Dungeon.hero && origin != null) {
+                                Badges.validateDeathFromFriendlyMagic();
+                                Dungeon.fail(origin);
+                                GLog.n(Messages.get(CursedWand.class, "ondeath", origin.name()));
+                            } else {
+                                Badges.validateDeathFromEnemyMagic();
+                                Dungeon.fail(toHeal);
+                            }
+                        }
+                    } else {
+                        Sample.INSTANCE.play(Assets.Sounds.BURNING);
+                    }
+                    tryForWandProc(target, origin);
+                } else {
+                    return cursedEffect(origin, user, targetPos);
+                }
+                return true;
 
-			//Bomb explosion
-			case 2:
-				new Bomb.MagicalBomb().explode(targetPos);
-				tryForWandProc(Actor.findChar(targetPos), origin);
-				return true;
+            // Bomb explosion
+            case 2:
+                new Bomb.MagicalBomb().explode(targetPos);
+                tryForWandProc(Actor.findChar(targetPos), origin);
+                return true;
 
-			//shock and recharge
-			case 3:
-				new ShockingTrap().set( user.pos ).activate();
-				Buff.prolong(user, Recharging.class, Recharging.DURATION);
-				ScrollOfRecharging.charge(user);
-				SpellSprite.show(user, SpellSprite.CHARGE);
-				return true;
-		}
+            // shock and recharge
+            case 3:
+                new ShockingTrap().set(user.pos).activate();
+                Buff.prolong(user, Recharging.class, Recharging.DURATION);
+                ScrollOfRecharging.charge(user);
+                SpellSprite.show(user, SpellSprite.CHARGE);
+                return true;
+        }
 
-	}
+    }
 
-	private static boolean rareEffect(final Item origin, final Char user, final int targetPos){
-		switch(Random.Int(4)){
+    private static boolean rareEffect(final Item origin, final Char user, final int targetPos) {
+        switch (Random.Int(4)) {
 
-			//sheep transformation
-			case 0: default:
+            // sheep transformation
+            case 0:
+            default:
 
-				Char ch = Actor.findChar( targetPos );
-				if (ch != null && !(ch instanceof Hero)
-						&& !ch.properties().contains(Char.Property.BOSS)
-						&& !ch.properties().contains(Char.Property.MINIBOSS)){
-					Sheep sheep = new Sheep();
-					sheep.lifespan = 10;
-					sheep.pos = ch.pos;
-					ch.destroy();
-					ch.sprite.killAndErase();
-					Dungeon.level.mobs.remove(ch);
-					TargetHealthIndicator.instance.target(null);
-					GameScene.add(sheep);
-					CellEmitter.get(sheep.pos).burst(Speck.factory(Speck.WOOL), 4);
-					Sample.INSTANCE.play(Assets.Sounds.PUFF);
-					Sample.INSTANCE.play(Assets.Sounds.SHEEP);
-				} else {
-					return cursedEffect(origin, user, targetPos);
-				}
-				return true;
+                Char ch = Actor.findChar(targetPos);
+                if (ch != null && !(ch instanceof Hero)
+                        && !ch.properties().contains(Char.Property.BOSS)
+                        && !ch.properties().contains(Char.Property.MINIBOSS)) {
+                    Sheep sheep = new Sheep();
+                    sheep.lifespan = 10;
+                    sheep.pos = ch.pos;
+                    ch.destroy();
+                    ch.sprite.killAndErase();
+                    Dungeon.level.mobs.remove(ch);
+                    TargetHealthIndicator.instance.target(null);
+                    GameScene.add(sheep);
+                    CellEmitter.get(sheep.pos).burst(Speck.factory(Speck.WOOL), 4);
+                    Sample.INSTANCE.play(Assets.Sounds.PUFF);
+                    Sample.INSTANCE.play(Assets.Sounds.SHEEP);
+                } else {
+                    return cursedEffect(origin, user, targetPos);
+                }
+                return true;
 
-			//curses!
-			case 1:
-				if (user instanceof Hero) {
-					CursingTrap.curse( (Hero) user );
-				} else {
-					return cursedEffect(origin, user, targetPos);
-				}
-				return true;
+            // curses!
+            case 1:
+                if (user instanceof Hero) {
+                    CursingTrap.curse((Hero) user);
+                } else {
+                    return cursedEffect(origin, user, targetPos);
+                }
+                return true;
 
-			//inter-level teleportation
-			case 2:
-				if (Dungeon.depth > 1 && Dungeon.interfloorTeleportAllowed() && user == Dungeon.hero) {
+            // inter-level teleportation
+            case 2:
+                if (Dungeon.depth > 1 && Dungeon.interfloorTeleportAllowed() && user == Dungeon.hero) {
 
-					//each depth has 1 more weight than the previous depth.
-					float[] depths = new float[Dungeon.depth-1];
-					for (int i = 1; i < Dungeon.depth; i++) depths[i-1] = i;
-					int depth = 1+Random.chances(depths);
+                    // each depth has 1 more weight than the previous depth.
+                    float[] depths = new float[Dungeon.depth - 1];
+                    for (int i = 1; i < Dungeon.depth; i++)
+                        depths[i - 1] = i;
+                    int depth = 1 + Random.chances(depths);
 
-					Level.beforeTransition();
-					InterlevelScene.mode = InterlevelScene.Mode.RETURN;
-					InterlevelScene.returnDepth = depth;
-					InterlevelScene.returnBranch = 0;
-					InterlevelScene.returnPos = -1;
-					Game.switchScene(InterlevelScene.class);
+                    Level.beforeTransition();
+                    InterlevelScene.mode = InterlevelScene.Mode.RETURN;
+                    InterlevelScene.returnDepth = depth;
+                    InterlevelScene.returnBranch = 0;
+                    InterlevelScene.returnPos = -1;
+                    Game.switchScene(InterlevelScene.class);
 
-				} else {
-					ScrollOfTeleportation.teleportChar(user);
+                } else {
+                    ScrollOfTeleportation.teleportChar(user);
 
-				}
-				return true;
+                }
+                return true;
 
-			//summon monsters
-			case 3:
-				new SummoningTrap().set( targetPos ).activate();
-				return true;
-		}
-	}
+            // summon monsters
+            case 3:
+                new SummoningTrap().set(targetPos).activate();
+                return true;
+        }
+    }
 
-	private static boolean veryRareEffect(final Item origin, final Char user, final int targetPos){
-		switch(Random.Int(4)){
+    private static boolean veryRareEffect(final Item origin, final Char user, final int targetPos) {
+        switch (Random.Int(4)) {
 
-			//great forest fire!
-			case 0: default:
-				for (int i = 0; i < Dungeon.level.length(); i++){
-					GameScene.add( Blob.seed(i, 15, Regrowth.class));
-				}
-				do {
-					GameScene.add(Blob.seed(Dungeon.level.randomDestination(null), 10, Fire.class));
-				} while (Random.Int(5) != 0);
-				new Flare(8, 32).color(0xFFFF66, true).show(user.sprite, 2f);
-				Sample.INSTANCE.play(Assets.Sounds.TELEPORT);
-				GLog.p(Messages.get(CursedWand.class, "grass"));
-				GLog.w(Messages.get(CursedWand.class, "fire"));
-				return true;
+            // great forest fire!
+            case 0:
+            default:
+                for (int i = 0; i < Dungeon.level.length(); i++) {
+                    GameScene.add(Blob.seed(i, 15, Regrowth.class));
+                }
+                do {
+                    GameScene.add(Blob.seed(Dungeon.level.randomDestination(null), 10, Fire.class));
+                } while (Random.Int(5) != 0);
+                new Flare(8, 32).color(0xFFFF66, true).show(user.sprite, 2f);
+                Sample.INSTANCE.play(Assets.Sounds.TELEPORT);
+                GLog.p(Messages.get(CursedWand.class, "grass"));
+                GLog.w(Messages.get(CursedWand.class, "fire"));
+                return true;
 
-			//golden mimic
-			case 1:
+            // golden mimic
+            case 1:
 
-				Char ch = Actor.findChar(targetPos);
-				int spawnCell = targetPos;
-				if (ch != null){
-					ArrayList<Integer> candidates = new ArrayList<Integer>();
-					for (int n : PathFinder.NEIGHBOURS8) {
-						int cell = targetPos + n;
-						if (Dungeon.level.passable[cell] && Actor.findChar( cell ) == null) {
-							candidates.add( cell );
-						}
-					}
-					if (!candidates.isEmpty()){
-						spawnCell = Random.element(candidates);
-					} else {
-						return cursedEffect(origin, user, targetPos);
-					}
-				}
+                Char ch = Actor.findChar(targetPos);
+                int spawnCell = targetPos;
+                if (ch != null) {
+                    ArrayList<Integer> candidates = new ArrayList<Integer>();
+                    for (int n : PathFinder.NEIGHBOURS8) {
+                        int cell = targetPos + n;
+                        if (Dungeon.level.passable[cell] && Actor.findChar(cell) == null) {
+                            candidates.add(cell);
+                        }
+                    }
+                    if (!candidates.isEmpty()) {
+                        spawnCell = Random.element(candidates);
+                    } else {
+                        return cursedEffect(origin, user, targetPos);
+                    }
+                }
 
-				Mimic mimic = Mimic.spawnAt(spawnCell, new ArrayList<Item>(), GoldenMimic.class);
-				mimic.stopHiding();
-				mimic.alignment = Char.Alignment.ENEMY;
-				Item reward;
-				do {
-					reward = Generator.randomUsingDefaults(Random.oneOf(Generator.Category.WEAPON, Generator.Category.ARMOR,
-							Generator.Category.RING, Generator.Category.WAND));
-				} while (reward.level() < 1);
-				//play vfx/sfx manually as mimic isn't in the scene yet
-				Sample.INSTANCE.play(Assets.Sounds.MIMIC, 1, 0.85f);
-				CellEmitter.get(mimic.pos).burst(Speck.factory(Speck.STAR), 10);
-				mimic.items.clear();
-				mimic.items.add(reward);
-				GameScene.add(mimic);
-				return true;
+                Mimic mimic = Mimic.spawnAt(spawnCell, new ArrayList<Item>(), GoldenMimic.class);
+                mimic.stopHiding();
+                mimic.alignment = Char.Alignment.ENEMY;
+                Item reward;
+                do {
+                    reward = Generator
+                            .randomUsingDefaults(Random.oneOf(Generator.Category.WEAPON, Generator.Category.ARMOR,
+                                    Generator.Category.RING, Generator.Category.WAND));
+                } while (reward.level() < 1);
+                // play vfx/sfx manually as mimic isn't in the scene yet
+                Sample.INSTANCE.play(Assets.Sounds.MIMIC, 1, 0.85f);
+                CellEmitter.get(mimic.pos).burst(Speck.factory(Speck.STAR), 10);
+                mimic.items.clear();
+                mimic.items.add(reward);
+                GameScene.add(mimic);
+                return true;
 
-			//crashes the game, yes, really.
-			case 2:
-				
-				try {
-					Dungeon.saveAll();
-					if(Messages.lang() != Languages.ENGLISH){
-						//Don't bother doing this joke to none-english speakers, I doubt it would translate.
-						return cursedEffect(origin, user, targetPos);
-					} else {
-						ShatteredPixelDungeon.runOnRenderThread(
-								new Callback() {
-									@Override
-									public void call() {
-										GameScene.show(
-												new WndOptions(Icons.get(Icons.WARNING),
-														"CURSED WAND ERROR",
-														"this application will now self-destruct",
-														"abort",
-														"retry",
-														"fail") {
+            // crashes the game, yes, really.
+            case 2:
 
-													@Override
-													protected void onSelect(int index) {
-														Game.instance.finish();
-													}
+                try {
+                    Dungeon.saveAll();
+                    if (Messages.lang() != Languages.ENGLISH) {
+                        // Don't bother doing this joke to none-english speakers, I doubt it would
+                        // translate.
+                        return cursedEffect(origin, user, targetPos);
+                    } else {
+                        ShatteredPixelDungeon.runOnRenderThread(
+                                new Callback() {
+                                    @Override
+                                    public void call() {
+                                        GameScene.show(
+                                                new WndOptions(Icons.get(Icons.WARNING),
+                                                        "CURSED WAND ERROR",
+                                                        "this application will now self-destruct",
+                                                        "abort",
+                                                        "retry",
+                                                        "fail") {
 
-													@Override
-													public void onBackPressed() {
-														//do nothing
-													}
-												}
-										);
-									}
-								}
-						);
-						return false;
-					}
-				} catch(IOException e){
-					ShatteredPixelDungeon.reportException(e);
-					//maybe don't kill the game if the save failed.
-					return cursedEffect(origin, user, targetPos);
-				}
+                                                    @Override
+                                                    protected void onSelect(int index) {
+                                                        Game.instance.finish();
+                                                    }
 
-			//random transmogrification
-			case 3:
-				//skips this effect if there is no item to transmogrify
-				if (origin == null || user != Dungeon.hero || !Dungeon.hero.belongings.contains(origin)){
-					return cursedEffect(origin, user, targetPos);
-				}
-				origin.detach(Dungeon.hero.belongings.backpack);
-				Item result;
-				do {
-					result = Generator.random(Random.oneOf(Generator.Category.WEAPON, Generator.Category.ARMOR,
-							Generator.Category.RING, Generator.Category.ARTIFACT));
-				} while (result.cursed);
-				if (result.isUpgradable()) result.upgrade();
-				result.cursed = result.cursedKnown = true;
-				if (origin instanceof Wand){
-					GLog.w( Messages.get(CursedWand.class, "transmogrify_wand") );
-				} else {
-					GLog.w( Messages.get(CursedWand.class, "transmogrify_other") );
-				}
-				Dungeon.level.drop(result, user.pos).sprite.drop();
-				return true;
-		}
-	}
+                                                    @Override
+                                                    public void onBackPressed() {
+                                                        // do nothing
+                                                    }
+                                                });
+                                    }
+                                });
+                        return false;
+                    }
+                } catch (IOException e) {
+                    ShatteredPixelDungeon.reportException(e);
+                    // maybe don't kill the game if the save failed.
+                    return cursedEffect(origin, user, targetPos);
+                }
 
-	private static void cursedFX(final Char user, final Ballistica bolt, final Callback callback){
-		MagicMissile.boltFromChar( user.sprite.parent,
-				MagicMissile.RAINBOW,
-				user.sprite,
-				bolt.collisionPos,
-				callback);
-		Sample.INSTANCE.play( Assets.Sounds.ZAP );
-	}
+                // random transmogrification
+            case 3:
+                // skips this effect if there is no item to transmogrify
+                if (origin == null || user != Dungeon.hero || !Dungeon.hero.belongings.contains(origin)) {
+                    return cursedEffect(origin, user, targetPos);
+                }
+                origin.detach(Dungeon.hero.belongings.backpack);
+                Item result;
+                do {
+                    result = Generator.random(Random.oneOf(Generator.Category.WEAPON, Generator.Category.ARMOR,
+                            Generator.Category.RING, Generator.Category.ARTIFACT));
+                } while (result.cursed);
+                if (result.isUpgradable())
+                    result.upgrade();
+                result.cursed = result.cursedKnown = true;
+                if (origin instanceof Wand) {
+                    GLog.w(Messages.get(CursedWand.class, "transmogrify_wand"));
+                } else {
+                    GLog.w(Messages.get(CursedWand.class, "transmogrify_other"));
+                }
+                Dungeon.level.drop(result, user.pos, true).sprite.drop();
+                return true;
+        }
+    }
+
+    private static void cursedFX(final Char user, final Ballistica bolt, final Callback callback) {
+        MagicMissile.boltFromChar(user.sprite.parent,
+                MagicMissile.RAINBOW,
+                user.sprite,
+                bolt.collisionPos,
+                callback);
+        Sample.INSTANCE.play(Assets.Sounds.ZAP);
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/MissileWeapon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/MissileWeapon.java
@@ -50,454 +50,465 @@ import java.util.ArrayList;
 
 abstract public class MissileWeapon extends Weapon {
 
-	{
-		stackable = true;
-		levelKnown = true;
-		
-		bones = true;
+    {
+        stackable = true;
+        levelKnown = true;
 
-		defaultAction = AC_THROW;
-		usesTargeting = true;
-	}
-	
-	protected boolean sticky = true;
-	
-	public static final float MAX_DURABILITY = 100;
-	protected float durability = MAX_DURABILITY;
-	protected float baseUses = 10;
-	
-	public boolean holster;
-	
-	//used to reduce durability from the source weapon stack, rather than the one being thrown.
-	protected MissileWeapon parent;
-	
-	public int tier;
-	
-	@Override
-	public int min() {
-		return Math.max(0, min( buffedLvl() + RingOfSharpshooting.levelDamageBonus(Dungeon.hero) ));
-	}
-	
-	@Override
-	public int min(int lvl) {
-		return  2 * tier +                      //base
-				(tier == 1 ? lvl : 2*lvl);      //level scaling
-	}
-	
-	@Override
-	public int max() {
-		return Math.max(0, max( buffedLvl() + RingOfSharpshooting.levelDamageBonus(Dungeon.hero) ));
-	}
-	
-	@Override
-	public int max(int lvl) {
-		return  5 * tier +                      //base
-				(tier == 1 ? 2*lvl : tier*lvl); //level scaling
-	}
-	
-	public int STRReq(int lvl){
-		return STRReq(tier, lvl) - 1; //1 less str than normal for their tier
-	}
-	
-	@Override
-	//FIXME some logic here assumes the items are in the player's inventory. Might need to adjust
-	public Item upgrade() {
-		if (!bundleRestoring) {
-			durability = MAX_DURABILITY;
-			if (quantity > 1) {
-				MissileWeapon upgraded = (MissileWeapon) split(1);
-				upgraded.parent = null;
-				
-				upgraded = (MissileWeapon) upgraded.upgrade();
-				
-				//try to put the upgraded into inventory, if it didn't already merge
-				if (upgraded.quantity() == 1 && !upgraded.collect()) {
-					Dungeon.level.drop(upgraded, Dungeon.hero.pos);
-				}
-				updateQuickslot();
-				return upgraded;
-			} else {
-				super.upgrade();
-				
-				Item similar = Dungeon.hero.belongings.getSimilar(this);
-				if (similar != null){
-					detach(Dungeon.hero.belongings.backpack);
-					Item result = similar.merge(this);
-					updateQuickslot();
-					return result;
-				}
-				updateQuickslot();
-				return this;
-			}
-			
-		} else {
-			return super.upgrade();
-		}
-	}
+        bones = true;
 
-	@Override
-	public ArrayList<String> actions( Hero hero ) {
-		ArrayList<String> actions = super.actions( hero );
-		actions.remove( AC_EQUIP );
-		return actions;
-	}
-	
-	@Override
-	public boolean collect(Bag container) {
-		if (container instanceof MagicalHolster) holster = true;
-		return super.collect(container);
-	}
-	
-	@Override
-	public int throwPos(Hero user, int dst) {
+        defaultAction = AC_THROW;
+        usesTargeting = true;
+    }
 
-		boolean projecting = hasEnchant(Projecting.class, user);
-		if (!projecting && Random.Int(3) < user.pointsInTalent(Talent.SHARED_ENCHANTMENT)){
-			if (this instanceof Dart && ((Dart) this).crossbowHasEnchant(Dungeon.hero)){
-				//do nothing
-			} else {
-				SpiritBow bow = Dungeon.hero.belongings.getItem(SpiritBow.class);
-				if (bow != null && bow.hasEnchant(Projecting.class, user)) {
-					projecting = true;
-				}
-			}
-		}
+    protected boolean sticky = true;
 
-		if (projecting
-				&& (Dungeon.level.passable[dst] || Dungeon.level.avoid[dst])
-				&& Dungeon.level.distance(user.pos, dst) <= Math.round(4 * Enchantment.genericProcChanceMultiplier(user))){
-			return dst;
-		} else {
-			return super.throwPos(user, dst);
-		}
-	}
+    public static final float MAX_DURABILITY = 100;
+    protected float durability = MAX_DURABILITY;
+    protected float baseUses = 10;
 
-	@Override
-	public float accuracyFactor(Char owner, Char target) {
-		float accFactor = super.accuracyFactor(owner, target);
-		if (owner instanceof Hero && owner.buff(Momentum.class) != null && owner.buff(Momentum.class).freerunning()){
-			accFactor *= 1f + 0.2f*((Hero) owner).pointsInTalent(Talent.PROJECTILE_MOMENTUM);
-		}
+    public boolean holster;
 
-		accFactor *= adjacentAccFactor(owner, target);
+    // used to reduce durability from the source weapon stack, rather than the one
+    // being thrown.
+    protected MissileWeapon parent;
 
-		return accFactor;
-	}
+    public int tier;
 
-	protected float adjacentAccFactor(Char owner, Char target){
-		if (Dungeon.level.adjacent( owner.pos, target.pos )) {
-			if (owner instanceof Hero){
-				return (0.5f + 0.2f*((Hero) owner).pointsInTalent(Talent.POINT_BLANK));
-			} else {
-				return 0.5f;
-			}
-		} else {
-			return 1.5f;
-		}
-	}
+    @Override
+    public int min() {
+        return Math.max(0, min(buffedLvl() + RingOfSharpshooting.levelDamageBonus(Dungeon.hero)));
+    }
 
-	@Override
-	public void doThrow(Hero hero) {
-		parent = null; //reset parent before throwing, just incase
-		super.doThrow(hero);
-	}
+    @Override
+    public int min(int lvl) {
+        return 2 * tier + // base
+                (tier == 1 ? lvl : 2 * lvl); // level scaling
+    }
 
-	@Override
-	protected void onThrow( int cell ) {
-		Char enemy = Actor.findChar( cell );
-		if (enemy == null || enemy == curUser) {
-			parent = null;
+    @Override
+    public int max() {
+        return Math.max(0, max(buffedLvl() + RingOfSharpshooting.levelDamageBonus(Dungeon.hero)));
+    }
 
-			//metamorphed seer shot logic
-			if (curUser.hasTalent(Talent.SEER_SHOT)
-					&& curUser.heroClass != HeroClass.HUNTRESS
-					&& curUser.buff(Talent.SeerShotCooldown.class) == null){
-				if (Actor.findChar(cell) == null) {
-					RevealedArea a = Buff.affect(curUser, RevealedArea.class, 5 * curUser.pointsInTalent(Talent.SEER_SHOT));
-					a.depth = Dungeon.depth;
-					a.pos = cell;
-					Buff.affect(curUser, Talent.SeerShotCooldown.class, 20f);
-				}
-			}
+    @Override
+    public int max(int lvl) {
+        return 5 * tier + // base
+                (tier == 1 ? 2 * lvl : tier * lvl); // level scaling
+    }
 
-			super.onThrow( cell );
-		} else {
-			if (!curUser.shoot( enemy, this )) {
-				rangedMiss( cell );
-			} else {
-				
-				rangedHit( enemy, cell );
+    public int STRReq(int lvl) {
+        return STRReq(tier, lvl) - 1; // 1 less str than normal for their tier
+    }
 
-			}
-		}
-	}
+    @Override
+    // FIXME some logic here assumes the items are in the player's inventory. Might
+    // need to adjust
+    public Item upgrade() {
+        if (!bundleRestoring) {
+            durability = MAX_DURABILITY;
+            if (quantity > 1) {
+                MissileWeapon upgraded = (MissileWeapon) split(1);
+                upgraded.parent = null;
 
-	@Override
-	public int proc(Char attacker, Char defender, int damage) {
-		if (attacker == Dungeon.hero && Random.Int(3) < Dungeon.hero.pointsInTalent(Talent.SHARED_ENCHANTMENT)){
-			if (this instanceof Dart && ((Dart) this).crossbowHasEnchant(Dungeon.hero)){
-				//do nothing
-			} else {
-				SpiritBow bow = Dungeon.hero.belongings.getItem(SpiritBow.class);
-				if (bow != null && bow.enchantment != null && Dungeon.hero.buff(MagicImmune.class) == null) {
-					damage = bow.enchantment.proc(this, attacker, defender, damage);
-				}
-			}
-		}
+                upgraded = (MissileWeapon) upgraded.upgrade();
 
-		return super.proc(attacker, defender, damage);
-	}
+                // try to put the upgraded into inventory, if it didn't already merge
+                if (upgraded.quantity() == 1 && !upgraded.collect()) {
+                    Dungeon.level.drop(upgraded, Dungeon.hero.pos);
+                }
+                updateQuickslot();
+                return upgraded;
+            } else {
+                super.upgrade();
 
-	@Override
-	public Item random() {
-		if (!stackable) return this;
-		
-		//2: 66.67% (2/3)
-		//3: 26.67% (4/15)
-		//4: 6.67%  (1/15)
-		quantity = 2;
-		if (Random.Int(3) == 0) {
-			quantity++;
-			if (Random.Int(5) == 0) {
-				quantity++;
-			}
-		}
-		return this;
-	}
+                Item similar = Dungeon.hero.belongings.getSimilar(this);
+                if (similar != null) {
+                    detach(Dungeon.hero.belongings.backpack);
+                    Item result = similar.merge(this);
+                    updateQuickslot();
+                    return result;
+                }
+                updateQuickslot();
+                return this;
+            }
 
-	public String status() {
-		//show quantity even when it is 1
-		return Integer.toString( quantity );
-	}
-	
-	@Override
-	public float castDelay(Char user, int dst) {
-		return delayFactor( user );
-	}
-	
-	protected void rangedHit( Char enemy, int cell ){
-		decrementDurability();
-		if (durability > 0){
-			//attempt to stick the missile weapon to the enemy, just drop it if we can't.
-			if (sticky && enemy != null && enemy.isAlive() && enemy.alignment != Char.Alignment.ALLY){
-				PinCushion p = Buff.affect(enemy, PinCushion.class);
-				if (p.target == enemy){
-					p.stick(this);
-					return;
-				}
-			}
-			Dungeon.level.drop( this, cell ).sprite.drop();
-		}
-	}
-	
-	protected void rangedMiss( int cell ) {
-		parent = null;
-		super.onThrow(cell);
-	}
+        } else {
+            return super.upgrade();
+        }
+    }
 
-	public float durabilityLeft(){
-		return durability;
-	}
+    @Override
+    public ArrayList<String> actions(Hero hero) {
+        ArrayList<String> actions = super.actions(hero);
+        actions.remove(AC_EQUIP);
+        return actions;
+    }
 
-	public void repair( float amount ){
-		durability += amount;
-		durability = Math.min(durability, MAX_DURABILITY);
-	}
-	
-	public float durabilityPerUse(){
-		float usages = baseUses * (float)(Math.pow(3, level()));
+    @Override
+    public boolean collect(Bag container) {
+        if (container instanceof MagicalHolster)
+            holster = true;
+        return super.collect(container);
+    }
 
-		//+50%/75% durability
-		if (Dungeon.hero.hasTalent(Talent.DURABLE_PROJECTILES)){
-			usages *= 1.25f + (0.25f*Dungeon.hero.pointsInTalent(Talent.DURABLE_PROJECTILES));
-		}
-		if (holster) {
-			usages *= MagicalHolster.HOLSTER_DURABILITY_FACTOR;
-		}
-		
-		usages *= RingOfSharpshooting.durabilityMultiplier( Dungeon.hero );
-		
-		//at 100 uses, items just last forever.
-		if (usages >= 100f) return 0;
+    @Override
+    public int throwPos(Hero user, int dst) {
 
-		usages = Math.round(usages);
-		
-		//add a tiny amount to account for rounding error for calculations like 1/3
-		return (MAX_DURABILITY/usages) + 0.001f;
-	}
-	
-	protected void decrementDurability(){
-		//if this weapon was thrown from a source stack, degrade that stack.
-		//unless a weapon is about to break, then break the one being thrown
-		if (parent != null){
-			if (parent.durability <= parent.durabilityPerUse()){
-				durability = 0;
-				parent.durability = MAX_DURABILITY;
-			} else {
-				parent.durability -= parent.durabilityPerUse();
-				if (parent.durability > 0 && parent.durability <= parent.durabilityPerUse()){
-					if (level() <= 0)GLog.w(Messages.get(this, "about_to_break"));
-					else             GLog.n(Messages.get(this, "about_to_break"));
-				}
-			}
-			parent = null;
-		} else {
-			durability -= durabilityPerUse();
-			if (durability > 0 && durability <= durabilityPerUse()){
-				if (level() <= 0)GLog.w(Messages.get(this, "about_to_break"));
-				else             GLog.n(Messages.get(this, "about_to_break"));
-			}
-		}
-	}
-	
-	@Override
-	public int damageRoll(Char owner) {
-		int damage = augment.damageFactor(super.damageRoll( owner ));
-		
-		if (owner instanceof Hero) {
-			int exStr = ((Hero)owner).STR() - STRReq();
-			if (exStr > 0) {
-				damage += Random.IntRange( 0, exStr );
-			}
-			if (owner.buff(Momentum.class) != null && owner.buff(Momentum.class).freerunning()) {
-				damage = Math.round(damage * (1f + 0.15f * ((Hero) owner).pointsInTalent(Talent.PROJECTILE_MOMENTUM)));
-			}
-		}
-		
-		return damage;
-	}
-	
-	@Override
-	public void reset() {
-		super.reset();
-		durability = MAX_DURABILITY;
-	}
-	
-	@Override
-	public Item merge(Item other) {
-		super.merge(other);
-		if (isSimilar(other)) {
-			durability += ((MissileWeapon)other).durability;
-			durability -= MAX_DURABILITY;
-			while (durability <= 0){
-				quantity -= 1;
-				durability += MAX_DURABILITY;
-			}
-		}
-		return this;
-	}
-	
-	@Override
-	public Item split(int amount) {
-		bundleRestoring = true;
-		Item split = super.split(amount);
-		bundleRestoring = false;
-		
-		//unless the thrown weapon will break, split off a max durability item and
-		//have it reduce the durability of the main stack. Cleaner to the player this way
-		if (split != null){
-			MissileWeapon m = (MissileWeapon)split;
-			m.durability = MAX_DURABILITY;
-			m.parent = this;
-		}
-		
-		return split;
-	}
-	
-	@Override
-	public boolean doPickUp(Hero hero, int pos) {
-		parent = null;
-		return super.doPickUp(hero, pos);
-	}
-	
-	@Override
-	public boolean isIdentified() {
-		return true;
-	}
-	
-	@Override
-	public String info() {
+        boolean projecting = hasEnchant(Projecting.class, user);
+        if (!projecting && Random.Int(3) < user.pointsInTalent(Talent.SHARED_ENCHANTMENT)) {
+            if (this instanceof Dart && ((Dart) this).crossbowHasEnchant(Dungeon.hero)) {
+                // do nothing
+            } else {
+                SpiritBow bow = Dungeon.hero.belongings.getItem(SpiritBow.class);
+                if (bow != null && bow.hasEnchant(Projecting.class, user)) {
+                    projecting = true;
+                }
+            }
+        }
 
-		String info = desc();
-		
-		info += "\n\n" + Messages.get( MissileWeapon.class, "stats",
-				tier,
-				Math.round(augment.damageFactor(min())),
-				Math.round(augment.damageFactor(max())),
-				STRReq());
+        if (projecting
+                && (Dungeon.level.passable[dst] || Dungeon.level.avoid[dst])
+                && Dungeon.level.distance(user.pos, dst) <= Math
+                        .round(4 * Enchantment.genericProcChanceMultiplier(user))) {
+            return dst;
+        } else {
+            return super.throwPos(user, dst);
+        }
+    }
 
-		if (STRReq() > Dungeon.hero.STR()) {
-			info += " " + Messages.get(Weapon.class, "too_heavy");
-		} else if (Dungeon.hero.STR() > STRReq()){
-			info += " " + Messages.get(Weapon.class, "excess_str", Dungeon.hero.STR() - STRReq());
-		}
+    @Override
+    public float accuracyFactor(Char owner, Char target) {
+        float accFactor = super.accuracyFactor(owner, target);
+        if (owner instanceof Hero && owner.buff(Momentum.class) != null && owner.buff(Momentum.class).freerunning()) {
+            accFactor *= 1f + 0.2f * ((Hero) owner).pointsInTalent(Talent.PROJECTILE_MOMENTUM);
+        }
 
-		if (enchantment != null && (cursedKnown || !enchantment.curse())){
-			info += "\n\n" + Messages.get(Weapon.class, "enchanted", enchantment.name());
-			info += " " + Messages.get(enchantment, "desc");
-		}
+        accFactor *= adjacentAccFactor(owner, target);
 
-		if (cursed && isEquipped( Dungeon.hero )) {
-			info += "\n\n" + Messages.get(Weapon.class, "cursed_worn");
-		} else if (cursedKnown && cursed) {
-			info += "\n\n" + Messages.get(Weapon.class, "cursed");
-		} else if (!isIdentified() && cursedKnown){
-			info += "\n\n" + Messages.get(Weapon.class, "not_cursed");
-		}
+        return accFactor;
+    }
 
-		info += "\n\n" + Messages.get(MissileWeapon.class, "distance");
-		
-		info += "\n\n" + Messages.get(this, "durability");
-		
-		if (durabilityPerUse() > 0){
-			info += " " + Messages.get(this, "uses_left",
-					(int)Math.ceil(durability/durabilityPerUse()),
-					(int)Math.ceil(MAX_DURABILITY/durabilityPerUse()));
-		} else {
-			info += " " + Messages.get(this, "unlimited_uses");
-		}
-		
-		
-		return info;
-	}
-	
-	@Override
-	public int value() {
-		return 6 * tier * quantity * (level() + 1);
-	}
-	
-	private static final String DURABILITY = "durability";
-	
-	@Override
-	public void storeInBundle(Bundle bundle) {
-		super.storeInBundle(bundle);
-		bundle.put(DURABILITY, durability);
-	}
-	
-	private static boolean bundleRestoring = false;
-	
-	@Override
-	public void restoreFromBundle(Bundle bundle) {
-		bundleRestoring = true;
-		super.restoreFromBundle(bundle);
-		bundleRestoring = false;
-		durability = bundle.getFloat(DURABILITY);
-	}
+    protected float adjacentAccFactor(Char owner, Char target) {
+        if (Dungeon.level.adjacent(owner.pos, target.pos)) {
+            if (owner instanceof Hero) {
+                return (0.5f + 0.2f * ((Hero) owner).pointsInTalent(Talent.POINT_BLANK));
+            } else {
+                return 0.5f;
+            }
+        } else {
+            return 1.5f;
+        }
+    }
 
-	public static class PlaceHolder extends MissileWeapon {
+    @Override
+    public void doThrow(Hero hero) {
+        parent = null; // reset parent before throwing, just incase
+        super.doThrow(hero);
+    }
 
-		{
-			image = ItemSpriteSheet.MISSILE_HOLDER;
-		}
+    @Override
+    protected void onThrow(int cell) {
+        Char enemy = Actor.findChar(cell);
+        if (enemy == null || enemy == curUser) {
+            parent = null;
 
-		@Override
-		public boolean isSimilar(Item item) {
-			return item instanceof MissileWeapon;
-		}
+            // metamorphed seer shot logic
+            if (curUser.hasTalent(Talent.SEER_SHOT)
+                    && curUser.heroClass != HeroClass.HUNTRESS
+                    && curUser.buff(Talent.SeerShotCooldown.class) == null) {
+                if (Actor.findChar(cell) == null) {
+                    RevealedArea a = Buff.affect(curUser, RevealedArea.class,
+                            5 * curUser.pointsInTalent(Talent.SEER_SHOT));
+                    a.depth = Dungeon.depth;
+                    a.pos = cell;
+                    Buff.affect(curUser, Talent.SeerShotCooldown.class, 20f);
+                }
+            }
 
-		@Override
-		public String info() {
-			return "";
-		}
-	}
+            super.onThrow(cell);
+        } else {
+            if (!curUser.shoot(enemy, this)) {
+                rangedMiss(cell);
+            } else {
+
+                rangedHit(enemy, cell);
+
+            }
+        }
+    }
+
+    @Override
+    public int proc(Char attacker, Char defender, int damage) {
+        if (attacker == Dungeon.hero && Random.Int(3) < Dungeon.hero.pointsInTalent(Talent.SHARED_ENCHANTMENT)) {
+            if (this instanceof Dart && ((Dart) this).crossbowHasEnchant(Dungeon.hero)) {
+                // do nothing
+            } else {
+                SpiritBow bow = Dungeon.hero.belongings.getItem(SpiritBow.class);
+                if (bow != null && bow.enchantment != null && Dungeon.hero.buff(MagicImmune.class) == null) {
+                    damage = bow.enchantment.proc(this, attacker, defender, damage);
+                }
+            }
+        }
+
+        return super.proc(attacker, defender, damage);
+    }
+
+    @Override
+    public Item random() {
+        if (!stackable)
+            return this;
+
+        // 2: 66.67% (2/3)
+        // 3: 26.67% (4/15)
+        // 4: 6.67% (1/15)
+        quantity = 2;
+        if (Random.Int(3) == 0) {
+            quantity++;
+            if (Random.Int(5) == 0) {
+                quantity++;
+            }
+        }
+        return this;
+    }
+
+    public String status() {
+        // show quantity even when it is 1
+        return Integer.toString(quantity);
+    }
+
+    @Override
+    public float castDelay(Char user, int dst) {
+        return delayFactor(user);
+    }
+
+    protected void rangedHit(Char enemy, int cell) {
+        decrementDurability();
+        if (durability > 0) {
+            // attempt to stick the missile weapon to the enemy, just drop it if we can't.
+            if (sticky && enemy != null && enemy.isAlive() && enemy.alignment != Char.Alignment.ALLY) {
+                PinCushion p = Buff.affect(enemy, PinCushion.class);
+                if (p.target == enemy) {
+                    p.stick(this);
+                    return;
+                }
+            }
+            Dungeon.level.drop(this, cell).sprite.drop();
+        }
+    }
+
+    protected void rangedMiss(int cell) {
+        parent = null;
+        super.onThrow(cell);
+    }
+
+    public float durabilityLeft() {
+        return durability;
+    }
+
+    public void repair(float amount) {
+        durability += amount;
+        durability = Math.min(durability, MAX_DURABILITY);
+    }
+
+    public float durabilityPerUse() {
+        float usages = baseUses * (float) (Math.pow(3, level()));
+
+        // +50%/75% durability
+        if (Dungeon.hero.hasTalent(Talent.DURABLE_PROJECTILES)) {
+            usages *= 1.25f + (0.25f * Dungeon.hero.pointsInTalent(Talent.DURABLE_PROJECTILES));
+        }
+        if (holster) {
+            usages *= MagicalHolster.HOLSTER_DURABILITY_FACTOR;
+        }
+
+        usages *= RingOfSharpshooting.durabilityMultiplier(Dungeon.hero);
+
+        // at 100 uses, items just last forever.
+        if (usages >= 100f)
+            return 0;
+
+        usages = Math.round(usages);
+
+        // add a tiny amount to account for rounding error for calculations like 1/3
+        return (MAX_DURABILITY / usages) + 0.001f;
+    }
+
+    protected void decrementDurability() {
+        // if this weapon was thrown from a source stack, degrade that stack.
+        // unless a weapon is about to break, then break the one being thrown
+        if (parent != null) {
+            if (parent.durability <= parent.durabilityPerUse()) {
+                durability = 0;
+                parent.durability = MAX_DURABILITY;
+            } else {
+                parent.durability -= parent.durabilityPerUse();
+                if (parent.durability > 0 && parent.durability <= parent.durabilityPerUse()) {
+                    if (level() <= 0)
+                        GLog.w(Messages.get(this, "about_to_break"));
+                    else
+                        GLog.n(Messages.get(this, "about_to_break"));
+                }
+            }
+            parent = null;
+        } else {
+            durability -= durabilityPerUse();
+            if (durability > 0 && durability <= durabilityPerUse()) {
+                if (level() <= 0)
+                    GLog.w(Messages.get(this, "about_to_break"));
+                else
+                    GLog.n(Messages.get(this, "about_to_break"));
+            }
+        }
+    }
+
+    @Override
+    public int damageRoll(Char owner) {
+        int damage = augment.damageFactor(super.damageRoll(owner));
+
+        if (owner instanceof Hero) {
+            int exStr = ((Hero) owner).STR() - STRReq();
+            if (exStr > 0) {
+                damage += Random.IntRange(0, exStr);
+            }
+            if (owner.buff(Momentum.class) != null && owner.buff(Momentum.class).freerunning()) {
+                damage = Math.round(damage * (1f + 0.15f * ((Hero) owner).pointsInTalent(Talent.PROJECTILE_MOMENTUM)));
+            }
+        }
+
+        return damage;
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        durability = MAX_DURABILITY;
+    }
+
+    @Override
+    public Item merge(Item other) {
+        super.merge(other);
+        if (isSimilar(other)) {
+            durability += ((MissileWeapon) other).durability;
+            durability -= MAX_DURABILITY;
+            while (durability <= 0) {
+                quantity -= 1;
+                durability += MAX_DURABILITY;
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public Item split(int amount) {
+        bundleRestoring = true;
+        Item split = super.split(amount);
+        bundleRestoring = false;
+
+        // unless the thrown weapon will break, split off a max durability item and
+        // have it reduce the durability of the main stack. Cleaner to the player this
+        // way
+        if (split != null) {
+            MissileWeapon m = (MissileWeapon) split;
+            m.durability = MAX_DURABILITY;
+            m.parent = this;
+        }
+
+        return split;
+    }
+
+    @Override
+    public boolean doPickUp(Hero hero, int pos, boolean isAutoLoot) {
+        parent = null;
+        return super.doPickUp(hero, pos, isAutoLoot);
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    @Override
+    public String info() {
+
+        String info = desc();
+
+        info += "\n\n" + Messages.get(MissileWeapon.class, "stats",
+                tier,
+                Math.round(augment.damageFactor(min())),
+                Math.round(augment.damageFactor(max())),
+                STRReq());
+
+        if (STRReq() > Dungeon.hero.STR()) {
+            info += " " + Messages.get(Weapon.class, "too_heavy");
+        } else if (Dungeon.hero.STR() > STRReq()) {
+            info += " " + Messages.get(Weapon.class, "excess_str", Dungeon.hero.STR() - STRReq());
+        }
+
+        if (enchantment != null && (cursedKnown || !enchantment.curse())) {
+            info += "\n\n" + Messages.get(Weapon.class, "enchanted", enchantment.name());
+            info += " " + Messages.get(enchantment, "desc");
+        }
+
+        if (cursed && isEquipped(Dungeon.hero)) {
+            info += "\n\n" + Messages.get(Weapon.class, "cursed_worn");
+        } else if (cursedKnown && cursed) {
+            info += "\n\n" + Messages.get(Weapon.class, "cursed");
+        } else if (!isIdentified() && cursedKnown) {
+            info += "\n\n" + Messages.get(Weapon.class, "not_cursed");
+        }
+
+        info += "\n\n" + Messages.get(MissileWeapon.class, "distance");
+
+        info += "\n\n" + Messages.get(this, "durability");
+
+        if (durabilityPerUse() > 0) {
+            info += " " + Messages.get(this, "uses_left",
+                    (int) Math.ceil(durability / durabilityPerUse()),
+                    (int) Math.ceil(MAX_DURABILITY / durabilityPerUse()));
+        } else {
+            info += " " + Messages.get(this, "unlimited_uses");
+        }
+
+        return info;
+    }
+
+    @Override
+    public int value() {
+        return 6 * tier * quantity * (level() + 1);
+    }
+
+    private static final String DURABILITY = "durability";
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        super.storeInBundle(bundle);
+        bundle.put(DURABILITY, durability);
+    }
+
+    private static boolean bundleRestoring = false;
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+        bundleRestoring = true;
+        super.restoreFromBundle(bundle);
+        bundleRestoring = false;
+        durability = bundle.getFloat(DURABILITY);
+    }
+
+    public static class PlaceHolder extends MissileWeapon {
+
+        {
+            image = ItemSpriteSheet.MISSILE_HOLDER;
+        }
+
+        @Override
+        public boolean isSimilar(Item item) {
+            return item instanceof MissileWeapon;
+        }
+
+        @Override
+        public String info() {
+            return "";
+        }
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
@@ -43,9 +43,11 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.PinCushion;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Regeneration;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.RevealedArea;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Shadows;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.SnipersMark;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.HeroSubClass;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
+import com.shatteredpixel.shatteredpixeldungeon.actors.hero.HeroAction.PickUp;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.abilities.huntress.SpiritHawk;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Bestiary;
 import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Mob;
@@ -102,1424 +104,1458 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 public abstract class Level implements Bundlable {
-	
-	public static enum Feeling {
-		NONE,
-		CHASM,
-		WATER,
-		GRASS,
-		DARK,
-		LARGE,
-		TRAPS,
-		SECRETS
-	}
-
-	protected int width;
-	protected int height;
-	protected int length;
-	
-	protected static final float TIME_TO_RESPAWN	= 50;
-
-	public int version;
-	
-	public int[] map;
-	public boolean[] visited;
-	public boolean[] mapped;
-	public boolean[] discoverable;
-
-	public int viewDistance = Dungeon.isChallenged( Challenges.DARKNESS ) ? 2 : 8;
-	
-	public boolean[] heroFOV;
-	
-	public boolean[] passable;
-	public boolean[] losBlocking;
-	public boolean[] flamable;
-	public boolean[] secret;
-	public boolean[] solid;
-	public boolean[] avoid;
-	public boolean[] water;
-	public boolean[] pit;
-
-	public boolean[] openSpace;
-	
-	public Feeling feeling = Feeling.NONE;
-	
-	public int entrance;
-	public int exit;
-
-	public ArrayList<LevelTransition> transitions;
-
-	//when a boss level has become locked.
-	public boolean locked = false;
-	
-	public HashSet<Mob> mobs;
-	public SparseArray<Heap> heaps;
-	public HashMap<Class<? extends Blob>,Blob> blobs;
-	public SparseArray<Plant> plants;
-	public SparseArray<Trap> traps;
-	public HashSet<CustomTilemap> customTiles;
-	public HashSet<CustomTilemap> customWalls;
-	
-	protected ArrayList<Item> itemsToSpawn = new ArrayList<>();
-
-	protected Group visuals;
-	
-	public int color1 = 0x004400;
-	public int color2 = 0x88CC44;
-
-	private static final String VERSION     = "version";
-	private static final String WIDTH       = "width";
-	private static final String HEIGHT      = "height";
-	private static final String MAP			= "map";
-	private static final String VISITED		= "visited";
-	private static final String MAPPED		= "mapped";
-	private static final String TRANSITIONS	= "transitions";
-	private static final String LOCKED      = "locked";
-	private static final String HEAPS		= "heaps";
-	private static final String PLANTS		= "plants";
-	private static final String TRAPS       = "traps";
-	private static final String CUSTOM_TILES= "customTiles";
-	private static final String CUSTOM_WALLS= "customWalls";
-	private static final String MOBS		= "mobs";
-	private static final String BLOBS		= "blobs";
-	private static final String FEELING		= "feeling";
-
-	public void create() {
-
-		Random.pushGenerator( Dungeon.seedCurDepth() );
-
-		//TODO maybe just make this part of RegularLevel?
-		if (!Dungeon.bossLevel() && Dungeon.branch == 0) {
-
-			addItemToSpawn(Generator.random(Generator.Category.FOOD));
-
-			if (Dungeon.isChallenged(Challenges.DARKNESS)){
-				addItemToSpawn( new Torch() );
-			}
-
-			if (Dungeon.posNeeded()) {
-				addItemToSpawn( new PotionOfStrength() );
-				Dungeon.LimitedDrops.STRENGTH_POTIONS.count++;
-			}
-			if (Dungeon.souNeeded()) {
-				addItemToSpawn( new ScrollOfUpgrade() );
-				Dungeon.LimitedDrops.UPGRADE_SCROLLS.count++;
-			}
-			if (Dungeon.asNeeded()) {
-				addItemToSpawn( new Stylus() );
-				Dungeon.LimitedDrops.ARCANE_STYLI.count++;
-			}
-			//one scroll of transmutation is guaranteed to spawn somewhere on chapter 2-4
-			int enchChapter = (int)((Dungeon.seed / 10) % 3) + 1;
-			if ( Dungeon.depth / 5 == enchChapter &&
-					Dungeon.seed % 4 + 1 == Dungeon.depth % 5){
-				addItemToSpawn( new StoneOfEnchantment() );
-			}
-			
-			if ( Dungeon.depth == ((Dungeon.seed % 3) + 1)){
-				addItemToSpawn( new StoneOfIntuition() );
-			}
-			
-			if (Dungeon.depth > 1) {
-				//50% chance of getting a level feeling
-				//~7.15% chance for each feeling
-				switch (Random.Int( 14 )) {
-					case 0:
-						feeling = Feeling.CHASM;
-						break;
-					case 1:
-						feeling = Feeling.WATER;
-						break;
-					case 2:
-						feeling = Feeling.GRASS;
-						break;
-					case 3:
-						feeling = Feeling.DARK;
-						addItemToSpawn(new Torch());
-						viewDistance = Math.round(viewDistance/2f);
-						break;
-					case 4:
-						feeling = Feeling.LARGE;
-						addItemToSpawn(Generator.random(Generator.Category.FOOD));
-						//add a second torch to help with the larger floor
-						if (Dungeon.isChallenged(Challenges.DARKNESS)){
-							addItemToSpawn( new Torch() );
-						}
-						break;
-					case 5:
-						feeling = Feeling.TRAPS;
-						break;
-					case 6:
-						feeling = Feeling.SECRETS;
-						break;
-				}
-			}
-		}
-		
-		do {
-			width = height = length = 0;
-
-			transitions = new ArrayList<>();
-
-			mobs = new HashSet<>();
-			heaps = new SparseArray<>();
-			blobs = new HashMap<>();
-			plants = new SparseArray<>();
-			traps = new SparseArray<>();
-			customTiles = new HashSet<>();
-			customWalls = new HashSet<>();
-			
-		} while (!build());
-		
-		buildFlagMaps();
-		cleanWalls();
-		
-		createMobs();
-		createItems();
-
-		Random.popGenerator();
-	}
-	
-	public void setSize(int w, int h){
-		
-		width = w;
-		height = h;
-		length = w * h;
-		
-		map = new int[length];
-		Arrays.fill( map, feeling == Level.Feeling.CHASM ? Terrain.CHASM : Terrain.WALL );
-		
-		visited     = new boolean[length];
-		mapped      = new boolean[length];
-		
-		heroFOV     = new boolean[length];
-		
-		passable	= new boolean[length];
-		losBlocking	= new boolean[length];
-		flamable	= new boolean[length];
-		secret		= new boolean[length];
-		solid		= new boolean[length];
-		avoid		= new boolean[length];
-		water		= new boolean[length];
-		pit			= new boolean[length];
-
-		openSpace   = new boolean[length];
-		
-		PathFinder.setMapSize(w, h);
-	}
-	
-	public void reset() {
-		
-		for (Mob mob : mobs.toArray( new Mob[0] )) {
-			if (!mob.reset()) {
-				mobs.remove( mob );
-			}
-		}
-		createMobs();
-	}
-
-	public void playLevelMusic(){
-		//do nothing by default
-	}
-	
-	@Override
-	public void restoreFromBundle( Bundle bundle ) {
-
-		version = bundle.getInt( VERSION );
-		
-		//saves from before v1.2.3 are not supported
-		if (version < ShatteredPixelDungeon.v1_2_3){
-			throw new RuntimeException("old save");
-		}
-
-		setSize( bundle.getInt(WIDTH), bundle.getInt(HEIGHT));
-		
-		mobs = new HashSet<>();
-		heaps = new SparseArray<>();
-		blobs = new HashMap<>();
-		plants = new SparseArray<>();
-		traps = new SparseArray<>();
-		customTiles = new HashSet<>();
-		customWalls = new HashSet<>();
-		
-		map		= bundle.getIntArray( MAP );
-
-		visited	= bundle.getBooleanArray( VISITED );
-		mapped	= bundle.getBooleanArray( MAPPED );
-
-		transitions = new ArrayList<>();
-		if (bundle.contains(TRANSITIONS)){
-			for (Bundlable b : bundle.getCollection( TRANSITIONS )){
-				transitions.add((LevelTransition) b);
-			}
-		//pre-1.3.0 saves, converts old entrance/exit to new transitions
-		} else {
-			if (bundle.contains("entrance")){
-				transitions.add(new LevelTransition(
-						this,
-						bundle.getInt("entrance"),
-						Dungeon.depth == 1 ? LevelTransition.Type.SURFACE : LevelTransition.Type.REGULAR_ENTRANCE));
-			}
-			if (bundle.contains("exit")){
-				transitions.add(new LevelTransition(this, bundle.getInt("exit"), LevelTransition.Type.REGULAR_EXIT));
-			}
-		}
-
-		locked      = bundle.getBoolean( LOCKED );
-		
-		Collection<Bundlable> collection = bundle.getCollection( HEAPS );
-		for (Bundlable h : collection) {
-			Heap heap = (Heap)h;
-			if (!heap.isEmpty())
-				heaps.put( heap.pos, heap );
-		}
-		
-		collection = bundle.getCollection( PLANTS );
-		for (Bundlable p : collection) {
-			Plant plant = (Plant)p;
-			plants.put( plant.pos, plant );
-		}
-
-		collection = bundle.getCollection( TRAPS );
-		for (Bundlable p : collection) {
-			Trap trap = (Trap)p;
-			traps.put( trap.pos, trap );
-		}
-
-		collection = bundle.getCollection( CUSTOM_TILES );
-		for (Bundlable p : collection) {
-			CustomTilemap vis = (CustomTilemap)p;
-			customTiles.add(vis);
-		}
-
-		collection = bundle.getCollection( CUSTOM_WALLS );
-		for (Bundlable p : collection) {
-			CustomTilemap vis = (CustomTilemap)p;
-			customWalls.add(vis);
-		}
-		
-		collection = bundle.getCollection( MOBS );
-		for (Bundlable m : collection) {
-			Mob mob = (Mob)m;
-			if (mob != null) {
-				mobs.add( mob );
-			}
-		}
-		
-		collection = bundle.getCollection( BLOBS );
-		for (Bundlable b : collection) {
-			Blob blob = (Blob)b;
-			blobs.put( blob.getClass(), blob );
-		}
-
-		feeling = bundle.getEnum( FEELING, Feeling.class );
-		if (feeling == Feeling.DARK)
-			viewDistance = Math.round(viewDistance/2f);
-
-		if (bundle.contains( "mobs_to_spawn" )) {
-			for (Class<? extends Mob> mob : bundle.getClassArray("mobs_to_spawn")) {
-				if (mob != null) mobsToSpawn.add(mob);
-			}
-		}
-
-		if (bundle.contains( "respawner" )){
-			respawner = (Respawner) bundle.get("respawner");
-		}
-
-		buildFlagMaps();
-		cleanWalls();
-
-	}
-	
-	@Override
-	public void storeInBundle( Bundle bundle ) {
-		bundle.put( VERSION, Game.versionCode );
-		bundle.put( WIDTH, width );
-		bundle.put( HEIGHT, height );
-		bundle.put( MAP, map );
-		bundle.put( VISITED, visited );
-		bundle.put( MAPPED, mapped );
-		bundle.put( TRANSITIONS, transitions );
-		bundle.put( LOCKED, locked );
-		bundle.put( HEAPS, heaps.valueList() );
-		bundle.put( PLANTS, plants.valueList() );
-		bundle.put( TRAPS, traps.valueList() );
-		bundle.put( CUSTOM_TILES, customTiles );
-		bundle.put( CUSTOM_WALLS, customWalls );
-		bundle.put( MOBS, mobs );
-		bundle.put( BLOBS, blobs.values() );
-		bundle.put( FEELING, feeling );
-		bundle.put( "mobs_to_spawn", mobsToSpawn.toArray(new Class[0]));
-		bundle.put( "respawner", respawner );
-	}
-	
-	public int tunnelTile() {
-		return feeling == Feeling.CHASM ? Terrain.EMPTY_SP : Terrain.EMPTY;
-	}
-
-	public int width() {
-		return width;
-	}
-
-	public int height() {
-		return height;
-	}
-
-	public int length() {
-		return length;
-	}
-	
-	public String tilesTex() {
-		return null;
-	}
-	
-	public String waterTex() {
-		return null;
-	}
-	
-	abstract protected boolean build();
-	
-	private ArrayList<Class<?extends Mob>> mobsToSpawn = new ArrayList<>();
-	
-	public Mob createMob() {
-		if (mobsToSpawn == null || mobsToSpawn.isEmpty()) {
-			mobsToSpawn = Bestiary.getMobRotation(Dungeon.depth);
-		}
-
-		Mob m = Reflection.newInstance(mobsToSpawn.remove(0));
-		ChampionEnemy.rollForChampion(m);
-		return m;
-	}
-
-	abstract protected void createMobs();
-
-	abstract protected void createItems();
-
-	public int entrance(){
-		LevelTransition l = getTransition(null);
-		if (l != null){
-			return l.cell();
-		}
-		return 0;
-	}
-
-	public int exit(){
-		LevelTransition l = getTransition(LevelTransition.Type.REGULAR_EXIT);
-		if (l != null){
-			return l.cell();
-		}
-		return 0;
-	}
-
-	public LevelTransition getTransition(LevelTransition.Type type){
-		if (transitions.isEmpty()){
-			return null;
-		}
-		for (LevelTransition transition : transitions){
-			//if we don't specify a type, prefer to return any entrance
-			if (type == null &&
-					(transition.type == LevelTransition.Type.REGULAR_ENTRANCE || transition.type == LevelTransition.Type.SURFACE)){
-				return transition;
-			} else if (transition.type == type){
-				return transition;
-			}
-		}
-		return type != null ? getTransition(null) : transitions.get(0);
-	}
-
-	public LevelTransition getTransition(int cell){
-		for (LevelTransition transition : transitions){
-			if (transition.inside(cell)){
-				return transition;
-			}
-		}
-		return null;
-	}
-
-	//some buff effects have special logic or are cancelled from the hero before transitioning levels
-	public static void beforeTransition(){
-
-		//time freeze effects need to resolve their pressed cells before transitioning
-		TimekeepersHourglass.timeFreeze timeFreeze = Dungeon.hero.buff(TimekeepersHourglass.timeFreeze.class);
-		if (timeFreeze != null) timeFreeze.disarmPresses();
-		Swiftthistle.TimeBubble timeBubble = Dungeon.hero.buff(Swiftthistle.TimeBubble.class);
-		if (timeBubble != null) timeBubble.disarmPresses();
-
-		//iron stomach does not persist through chasm falling
-		Talent.WarriorFoodImmunity foodImmune = Dungeon.hero.buff(Talent.WarriorFoodImmunity.class);
-		if (foodImmune != null) foodImmune.detach();
-
-		//spend the hero's partial turns,  so the hero cannot take partial turns between floors
-		Dungeon.hero.spendToWhole();
-		for (Char ch : Actor.chars()){
-			//also adjust any mobs that are now ahead of the hero due to this
-			if (ch.cooldown() < Dungeon.hero.cooldown()){
-				ch.spendToWhole();
-			}
-		}
-	}
-
-	public void seal(){
-		if (!locked) {
-			locked = true;
-			Buff.affect(Dungeon.hero, LockedFloor.class);
-		}
-	}
-
-	public void unseal(){
-		if (locked) {
-			locked = false;
-			if (Dungeon.hero.buff(LockedFloor.class) != null){
-				Dungeon.hero.buff(LockedFloor.class).detach();
-			}
-		}
-	}
-
-	public ArrayList<Item> getItemsToPreserveFromSealedResurrect(){
-		ArrayList<Item> items = new ArrayList<>();
-		for (Heap h : heaps.valueList()){
-			if (h.type == Heap.Type.HEAP) items.addAll(h.items);
-		}
-		for (Mob m : mobs){
-			for (PinCushion b : m.buffs(PinCushion.class)){
-				items.addAll(b.getStuckItems());
-			}
-		}
-		for (HeavyBoomerang.CircleBack b : Dungeon.hero.buffs(HeavyBoomerang.CircleBack.class)){
-			if (b.activeDepth() == Dungeon.depth) items.add(b.cancel());
-		}
-		return items;
-	}
-
-	public Group addVisuals() {
-		if (visuals == null || visuals.parent == null){
-			visuals = new Group();
-		} else {
-			visuals.clear();
-			visuals.camera = null;
-		}
-		for (int i=0; i < length(); i++) {
-			if (pit[i]) {
-				visuals.add( new WindParticle.Wind( i ) );
-				if (i >= width() && water[i-width()]) {
-					visuals.add( new FlowParticle.Flow( i - width() ) );
-				}
-			}
-		}
-		return visuals;
-	}
-	
-	public int mobLimit() {
-		return 0;
-	}
-
-	public int mobCount(){
-		float count = 0;
-		for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])){
-			if (mob.alignment == Char.Alignment.ENEMY && !mob.properties().contains(Char.Property.MINIBOSS)) {
-				count += mob.spawningWeight();
-			}
-		}
-		return Math.round(count);
-	}
-
-	public Mob findMob( int pos ){
-		for (Mob mob : mobs){
-			if (mob.pos == pos){
-				return mob;
-			}
-		}
-		return null;
-	}
-
-	private Respawner respawner;
-
-	public Actor addRespawner() {
-		if (respawner == null){
-			respawner = new Respawner();
-			Actor.addDelayed(respawner, respawnCooldown());
-		} else {
-			Actor.add(respawner);
-			if (respawner.cooldown() > respawnCooldown()){
-				respawner.resetCooldown();
-			}
-		}
-		return respawner;
-	}
-
-	public static class Respawner extends Actor {
-		{
-			actPriority = BUFF_PRIO; //as if it were a buff.
-		}
-
-		@Override
-		protected boolean act() {
-
-			if (Dungeon.level.mobCount() < Dungeon.level.mobLimit()) {
-
-				if (Dungeon.level.spawnMob(12)){
-					spend(Dungeon.level.respawnCooldown());
-				} else {
-					//try again in 1 turn
-					spend(TICK);
-				}
-
-			} else {
-				spend(Dungeon.level.respawnCooldown());
-			}
-
-			return true;
-		}
-
-		protected void resetCooldown(){
-			spend(-cooldown());
-			spend(Dungeon.level.respawnCooldown());
-		}
-	}
-
-	public float respawnCooldown(){
-		if (Statistics.amuletObtained){
-			if (Dungeon.depth == 1){
-				//very fast spawns on floor 1! 0/2/4/6/8/10/12, etc.
-				return (Dungeon.level.mobCount()) * (TIME_TO_RESPAWN / 25f);
-			} else {
-				//respawn time is 5/5/10/15/20/25/25, etc.
-				return Math.round(GameMath.gate( TIME_TO_RESPAWN/10f, Dungeon.level.mobCount() * (TIME_TO_RESPAWN / 10f), TIME_TO_RESPAWN / 2f));
-			}
-		} else if (Dungeon.level.feeling == Feeling.DARK){
-			return 2*TIME_TO_RESPAWN/3f;
-		} else {
-			return TIME_TO_RESPAWN;
-		}
-	}
-
-	public boolean spawnMob(int disLimit){
-		PathFinder.buildDistanceMap(Dungeon.hero.pos, BArray.or(passable, avoid, null));
-
-		Mob mob = createMob();
-		mob.state = mob.WANDERING;
-		int tries = 30;
-		do {
-			mob.pos = randomRespawnCell(mob);
-			tries--;
-		} while ((mob.pos == -1 || PathFinder.distance[mob.pos] < disLimit) && tries > 0);
-
-		if (Dungeon.hero.isAlive() && mob.pos != -1 && PathFinder.distance[mob.pos] >= disLimit) {
-			GameScene.add( mob );
-			if (!mob.buffs(ChampionEnemy.class).isEmpty()){
-				GLog.w(Messages.get(ChampionEnemy.class, "warn"));
-			}
-			return true;
-		} else {
-			return false;
-		}
-	}
-	
-	public int randomRespawnCell( Char ch ) {
-		int cell;
-		int count = 0;
-		do {
-
-			if (++count > 30) {
-				return -1;
-			}
-
-			cell = Random.Int( length() );
-
-		} while ((Dungeon.level == this && heroFOV[cell])
-				|| !passable[cell]
-				|| (Char.hasProp(ch, Char.Property.LARGE) && !openSpace[cell])
-				|| Actor.findChar( cell ) != null);
-		return cell;
-	}
-	
-	public int randomDestination( Char ch ) {
-		int cell;
-		do {
-			cell = Random.Int( length() );
-		} while (!passable[cell]
-				|| (Char.hasProp(ch, Char.Property.LARGE) && !openSpace[cell]));
-		return cell;
-	}
-	
-	public void addItemToSpawn( Item item ) {
-		if (item != null) {
-			itemsToSpawn.add( item );
-		}
-	}
-
-	public Item findPrizeItem(){ return findPrizeItem(null); }
-
-	public Item findPrizeItem(Class<?extends Item> match){
-		if (itemsToSpawn.size() == 0)
-			return null;
-
-		if (match == null){
-			Item item = Random.element(itemsToSpawn);
-			itemsToSpawn.remove(item);
-			return item;
-		}
-
-		for (Item item : itemsToSpawn){
-			if (match.isInstance(item)){
-				itemsToSpawn.remove( item );
-				return item;
-			}
-		}
-
-		return null;
-	}
-
-	public void buildFlagMaps() {
-		
-		for (int i=0; i < length(); i++) {
-			int flags = Terrain.flags[map[i]];
-			passable[i]		= (flags & Terrain.PASSABLE) != 0;
-			losBlocking[i]	= (flags & Terrain.LOS_BLOCKING) != 0;
-			flamable[i]		= (flags & Terrain.FLAMABLE) != 0;
-			secret[i]		= (flags & Terrain.SECRET) != 0;
-			solid[i]		= (flags & Terrain.SOLID) != 0;
-			avoid[i]		= (flags & Terrain.AVOID) != 0;
-			water[i]		= (flags & Terrain.LIQUID) != 0;
-			pit[i]			= (flags & Terrain.PIT) != 0;
-		}
-
-		for (Blob b : blobs.values()){
-			b.onBuildFlagMaps(this);
-		}
-		
-		int lastRow = length() - width();
-		for (int i=0; i < width(); i++) {
-			passable[i] = avoid[i] = false;
-			losBlocking[i] = solid[i] = true;
-			passable[lastRow + i] = avoid[lastRow + i] = false;
-			losBlocking[lastRow + i] = solid[lastRow + i] = true;
-		}
-		for (int i=width(); i < lastRow; i += width()) {
-			passable[i] = avoid[i] = false;
-			losBlocking[i] = solid[i] = true;
-			passable[i + width()-1] = avoid[i + width()-1] = false;
-			losBlocking[i + width()-1] = solid[i + width()-1] = true;
-		}
-
-		//an open space is large enough to fit large mobs. A space is open when it is not solid
-		// and there is an open corner with both adjacent cells opens
-		for (int i=0; i < length(); i++) {
-			if (solid[i]){
-				openSpace[i] = false;
-			} else {
-				for (int j = 1; j < PathFinder.CIRCLE8.length; j += 2){
-					if (solid[i+PathFinder.CIRCLE8[j]]) {
-						openSpace[i] = false;
-					} else if (!solid[i+PathFinder.CIRCLE8[(j+1)%8]]
-							&& !solid[i+PathFinder.CIRCLE8[(j+2)%8]]){
-						openSpace[i] = true;
-						break;
-					}
-				}
-			}
-		}
-
-	}
-
-	public void destroy( int pos ) {
-		//if raw tile type is flammable or empty
-		int terr = map[pos];
-		if (terr == Terrain.EMPTY || terr == Terrain.EMPTY_DECO
-				|| (Terrain.flags[map[pos]] & Terrain.FLAMABLE) != 0) {
-			set(pos, Terrain.EMBERS);
-		}
-		Blob web = blobs.get(Web.class);
-		if (web != null){
-			web.clear(pos);
-		}
-	}
-
-	public void cleanWalls() {
-		if (discoverable == null || discoverable.length != length) {
-			discoverable = new boolean[length()];
-		}
-
-		for (int i=0; i < length(); i++) {
-			
-			boolean d = false;
-			
-			for (int j=0; j < PathFinder.NEIGHBOURS9.length; j++) {
-				int n = i + PathFinder.NEIGHBOURS9[j];
-				if (n >= 0 && n < length() && map[n] != Terrain.WALL && map[n] != Terrain.WALL_DECO) {
-					d = true;
-					break;
-				}
-			}
-			
-			discoverable[i] = d;
-		}
-	}
-	
-	public static void set( int cell, int terrain ){
-		set( cell, terrain, Dungeon.level );
-	}
-	
-	public static void set( int cell, int terrain, Level level ) {
-		Painter.set( level, cell, terrain );
-
-		if (terrain != Terrain.TRAP && terrain != Terrain.SECRET_TRAP && terrain != Terrain.INACTIVE_TRAP){
-			level.traps.remove( cell );
-		}
-
-		int flags = Terrain.flags[terrain];
-		level.passable[cell]		= (flags & Terrain.PASSABLE) != 0;
-		level.losBlocking[cell]	    = (flags & Terrain.LOS_BLOCKING) != 0;
-		level.flamable[cell]		= (flags & Terrain.FLAMABLE) != 0;
-		level.secret[cell]		    = (flags & Terrain.SECRET) != 0;
-		level.solid[cell]			= (flags & Terrain.SOLID) != 0;
-		level.avoid[cell]			= (flags & Terrain.AVOID) != 0;
-		level.pit[cell]			    = (flags & Terrain.PIT) != 0;
-		level.water[cell]			= terrain == Terrain.WATER;
-
-		for (int i : PathFinder.NEIGHBOURS9){
-			i = cell + i;
-			if (level.solid[i]){
-				level.openSpace[i] = false;
-			} else {
-				for (int j = 1; j < PathFinder.CIRCLE8.length; j += 2){
-					if (level.solid[i+PathFinder.CIRCLE8[j]]) {
-						level.openSpace[i] = false;
-					} else if (!level.solid[i+PathFinder.CIRCLE8[(j+1)%8]]
-							&& !level.solid[i+PathFinder.CIRCLE8[(j+2)%8]]){
-						level.openSpace[i] = true;
-						break;
-					}
-				}
-			}
-		}
-	}
-	
-	public Heap drop( Item item, int cell ) {
-
-		if (item == null || Challenges.isItemBlocked(item)){
-
-			//create a dummy heap, give it a dummy sprite, don't add it to the game, and return it.
-			//effectively nullifies whatever the logic calling this wants to do, including dropping items.
-			Heap heap = new Heap();
-			ItemSprite sprite = heap.sprite = new ItemSprite();
-			sprite.link(heap);
-			return heap;
-
-		}
-		
-		Heap heap = heaps.get( cell );
-		if (heap == null) {
-			
-			heap = new Heap();
-			heap.seen = Dungeon.level == this && heroFOV[cell];
-			heap.pos = cell;
-			heap.drop(item);
-			if (map[cell] == Terrain.CHASM || (Dungeon.level != null && pit[cell])) {
-				Dungeon.dropToChasm( item );
-				GameScene.discard( heap );
-			} else {
-				heaps.put( cell, heap );
-				GameScene.add( heap );
-			}
-			
-		} else if (heap.type == Heap.Type.LOCKED_CHEST || heap.type == Heap.Type.CRYSTAL_CHEST) {
-			
-			int n;
-			do {
-				n = cell + PathFinder.NEIGHBOURS8[Random.Int( 8 )];
-			} while (!passable[n] && !avoid[n]);
-			return drop( item, n );
-			
-		} else {
-			heap.drop(item);
-		}
-		
-		if (Dungeon.level != null && ShatteredPixelDungeon.scene() instanceof GameScene) {
-			pressCell( cell );
-		}
-		
-		return heap;
-	}
-	
-	public Plant plant( Plant.Seed seed, int pos ) {
-		
-		if (Dungeon.isChallenged(Challenges.NO_HERBALISM)){
-			return null;
-		}
-
-		Plant plant = plants.get( pos );
-		if (plant != null) {
-			plant.wither();
-		}
-
-		if (map[pos] == Terrain.HIGH_GRASS ||
-				map[pos] == Terrain.FURROWED_GRASS ||
-				map[pos] == Terrain.EMPTY ||
-				map[pos] == Terrain.EMBERS ||
-				map[pos] == Terrain.EMPTY_DECO) {
-			set(pos, Terrain.GRASS, this);
-			GameScene.updateMap(pos);
-		}
-		
-		plant = seed.couch( pos, this );
-		plants.put( pos, plant );
-		
-		GameScene.plantSeed( pos );
-
-		for (Char ch : Actor.chars()){
-			if (ch instanceof WandOfRegrowth.Lotus
-					&& ((WandOfRegrowth.Lotus) ch).inRange(pos)
-					&& Actor.findChar(pos) != null){
-				plant.trigger();
-				return null;
-			}
-		}
-		
-		return plant;
-	}
-	
-	public void uproot( int pos ) {
-		plants.remove(pos);
-		GameScene.updateMap( pos );
-	}
-
-	public Trap setTrap( Trap trap, int pos ){
-		Trap existingTrap = traps.get(pos);
-		if (existingTrap != null){
-			traps.remove( pos );
-		}
-		trap.set( pos );
-		traps.put( pos, trap );
-		GameScene.updateMap( pos );
-		return trap;
-	}
-
-	public void disarmTrap( int pos ) {
-		set(pos, Terrain.INACTIVE_TRAP);
-		GameScene.updateMap(pos);
-	}
-
-	public void discover( int cell ) {
-		set( cell, Terrain.discover( map[cell] ) );
-		Trap trap = traps.get( cell );
-		if (trap != null)
-			trap.reveal();
-		GameScene.updateMap( cell );
-	}
-
-	public boolean setCellToWater( boolean includeTraps, int cell ){
-		Point p = cellToPoint(cell);
-
-		//if a custom tilemap is over that cell, don't put water there
-		for (CustomTilemap cust : customTiles){
-			Point custPoint = new Point(p);
-			custPoint.x -= cust.tileX;
-			custPoint.y -= cust.tileY;
-			if (custPoint.x >= 0 && custPoint.y >= 0
-					&& custPoint.x < cust.tileW && custPoint.y < cust.tileH){
-				if (cust.image(custPoint.x, custPoint.y) != null){
-					return false;
-				}
-			}
-		}
-
-		int terr = map[cell];
-		if (terr == Terrain.EMPTY || terr == Terrain.GRASS ||
-				terr == Terrain.EMBERS || terr == Terrain.EMPTY_SP ||
-				terr == Terrain.HIGH_GRASS || terr == Terrain.FURROWED_GRASS
-				|| terr == Terrain.EMPTY_DECO){
-			set(cell, Terrain.WATER);
-			GameScene.updateMap(cell);
-			return true;
-		} else if (includeTraps && (terr == Terrain.SECRET_TRAP ||
-				terr == Terrain.TRAP || terr == Terrain.INACTIVE_TRAP)){
-			set(cell, Terrain.WATER);
-			Dungeon.level.traps.remove(cell);
-			GameScene.updateMap(cell);
-			return true;
-		}
-
-		return false;
-	}
-	
-	public int fallCell( boolean fallIntoPit ) {
-		int result;
-		do {
-			result = randomRespawnCell( null );
-			if (result == -1) return -1;
-		} while (traps.get(result) != null
-				|| findMob(result) != null);
-		return result;
-	}
-	
-	public void occupyCell( Char ch ){
-		if (!ch.isImmune(Web.class) && Blob.volumeAt(ch.pos, Web.class) > 0){
-			blobs.get(Web.class).clear(ch.pos);
-			Web.affectChar( ch );
-		}
-
-		if (!ch.flying){
-
-			if ( (map[ch.pos] == Terrain.GRASS || map[ch.pos] == Terrain.EMBERS)
-					&& ch == Dungeon.hero && Dungeon.hero.hasTalent(Talent.REJUVENATING_STEPS)
-					&& ch.buff(Talent.RejuvenatingStepsCooldown.class) == null){
-
-				if (!Regeneration.regenOn()){
-					set(ch.pos, Terrain.FURROWED_GRASS);
-				} else if (ch.buff(Talent.RejuvenatingStepsFurrow.class) != null && ch.buff(Talent.RejuvenatingStepsFurrow.class).count() >= 200) {
-					set(ch.pos, Terrain.FURROWED_GRASS);
-				} else {
-					set(ch.pos, Terrain.HIGH_GRASS);
-					Buff.count(ch, Talent.RejuvenatingStepsFurrow.class, 3 - Dungeon.hero.pointsInTalent(Talent.REJUVENATING_STEPS));
-				}
-				GameScene.updateMap(ch.pos);
-				Buff.affect(ch, Talent.RejuvenatingStepsCooldown.class, 15f - 5f*Dungeon.hero.pointsInTalent(Talent.REJUVENATING_STEPS));
-			}
-			
-			if (pit[ch.pos]){
-				if (ch == Dungeon.hero) {
-					Chasm.heroFall(ch.pos);
-				} else if (ch instanceof Mob) {
-					Chasm.mobFall( (Mob)ch );
-				}
-				return;
-			}
-			
-			//characters which are not the hero or a sheep 'soft' press cells
-			pressCell( ch.pos, ch instanceof Hero || ch instanceof Sheep);
-		} else {
-			if (map[ch.pos] == Terrain.DOOR){
-				Door.enter( ch.pos );
-			}
-		}
-
-		if (ch.isAlive() && ch instanceof Piranha && !water[ch.pos]){
-			((Piranha) ch).dieOnLand();
-		}
-	}
-	
-	//public method for forcing the hard press of a cell. e.g. when an item lands on it
-	public void pressCell( int cell ){
-		pressCell( cell, true );
-	}
-	
-	//a 'soft' press ignores hidden traps
-	//a 'hard' press triggers all things
-	private void pressCell( int cell, boolean hard ) {
-
-		Trap trap = null;
-		
-		switch (map[cell]) {
-		
-		case Terrain.SECRET_TRAP:
-			if (hard) {
-				trap = traps.get( cell );
-				GLog.i(Messages.get(Level.class, "hidden_trap", trap.name()));
-			}
-			break;
-			
-		case Terrain.TRAP:
-			trap = traps.get( cell );
-			break;
-			
-		case Terrain.HIGH_GRASS:
-		case Terrain.FURROWED_GRASS:
-			HighGrass.trample( this, cell);
-			break;
-			
-		case Terrain.WELL:
-			WellWater.affectCell( cell );
-			break;
-			
-		case Terrain.DOOR:
-			Door.enter( cell );
-			break;
-		}
-
-		TimekeepersHourglass.timeFreeze timeFreeze =
-				Dungeon.hero.buff(TimekeepersHourglass.timeFreeze.class);
-
-		Swiftthistle.TimeBubble bubble =
-				Dungeon.hero.buff(Swiftthistle.TimeBubble.class);
-
-		if (trap != null) {
-			if (bubble != null){
-				Sample.INSTANCE.play(Assets.Sounds.TRAP);
-				discover(cell);
-				bubble.setDelayedPress(cell);
-				
-			} else if (timeFreeze != null){
-				Sample.INSTANCE.play(Assets.Sounds.TRAP);
-				discover(cell);
-				timeFreeze.setDelayedPress(cell);
-				
-			} else {
-				if (Dungeon.hero.pos == cell) {
-					Dungeon.hero.interrupt();
-				}
-				trap.trigger();
-
-			}
-		}
-		
-		Plant plant = plants.get( cell );
-		if (plant != null) {
-			if (bubble != null){
-				Sample.INSTANCE.play(Assets.Sounds.TRAMPLE, 1, Random.Float( 0.96f, 1.05f ) );
-				bubble.setDelayedPress(cell);
-
-			} else if (timeFreeze != null){
-				Sample.INSTANCE.play(Assets.Sounds.TRAMPLE, 1, Random.Float( 0.96f, 1.05f ) );
-				timeFreeze.setDelayedPress(cell);
-
-			} else {
-				plant.trigger();
-
-			}
-		}
-
-		if (hard && Blob.volumeAt(cell, Web.class) > 0){
-			blobs.get(Web.class).clear(cell);
-		}
-	}
-
-	private static boolean[] heroMindFov;
-
-	private static boolean[] modifiableBlocking;
-
-	public void updateFieldOfView( Char c, boolean[] fieldOfView ) {
-
-		int cx = c.pos % width();
-		int cy = c.pos / width();
-		
-		boolean sighted = c.buff( Blindness.class ) == null && c.buff( Shadows.class ) == null
-						&& c.buff( TimekeepersHourglass.timeStasis.class ) == null && c.isAlive();
-		if (sighted) {
-			boolean[] blocking = null;
-
-			if (modifiableBlocking == null || modifiableBlocking.length != Dungeon.level.losBlocking.length){
-				modifiableBlocking = new boolean[Dungeon.level.losBlocking.length];
-			}
-			
-			if ((c instanceof Hero && ((Hero) c).subClass == HeroSubClass.WARDEN)
-				|| c instanceof YogFist.SoiledFist) {
-				if (blocking == null) {
-					System.arraycopy(Dungeon.level.losBlocking, 0, modifiableBlocking, 0, modifiableBlocking.length);
-					blocking = modifiableBlocking;
-				}
-				for (int i = 0; i < blocking.length; i++){
-					if (blocking[i] && (Dungeon.level.map[i] == Terrain.HIGH_GRASS || Dungeon.level.map[i] == Terrain.FURROWED_GRASS)){
-						blocking[i] = false;
-					}
-				}
-			}
-
-			if (c.alignment != Char.Alignment.ALLY
-					&& Dungeon.level.blobs.containsKey(SmokeScreen.class)
-					&& Dungeon.level.blobs.get(SmokeScreen.class).volume > 0) {
-				if (blocking == null) {
-					System.arraycopy(Dungeon.level.losBlocking, 0, modifiableBlocking, 0, modifiableBlocking.length);
-					blocking = modifiableBlocking;
-				}
-				Blob s = Dungeon.level.blobs.get(SmokeScreen.class);
-				for (int i = 0; i < blocking.length; i++){
-					if (!blocking[i] && s.cur[i] > 0){
-						blocking[i] = true;
-					}
-				}
-			}
-
-			if (blocking == null){
-				blocking = Dungeon.level.losBlocking;
-			}
-			
-			int viewDist = c.viewDistance;
-			if (c instanceof Hero){
-				viewDist *= 1f + 0.25f*((Hero) c).pointsInTalent(Talent.FARSIGHT);
-			}
-			
-			ShadowCaster.castShadow( cx, cy, fieldOfView, blocking, viewDist );
-		} else {
-			BArray.setFalse(fieldOfView);
-		}
-		
-		int sense = 1;
-		//Currently only the hero can get mind vision
-		if (c.isAlive() && c == Dungeon.hero) {
-			for (Buff b : c.buffs( MindVision.class )) {
-				sense = Math.max( ((MindVision)b).distance, sense );
-			}
-			if (c.buff(MagicalSight.class) != null){
-				sense = Math.max( MagicalSight.DISTANCE, sense );
-			}
-		}
-		
-		//uses rounding
-		if (!sighted || sense > 1) {
-			
-			int[][] rounding = ShadowCaster.rounding;
-			
-			int left, right;
-			int pos;
-			for (int y = Math.max(0, cy - sense); y <= Math.min(height()-1, cy + sense); y++) {
-				if (rounding[sense][Math.abs(cy - y)] < Math.abs(cy - y)) {
-					left = cx - rounding[sense][Math.abs(cy - y)];
-				} else {
-					left = sense;
-					while (rounding[sense][left] < rounding[sense][Math.abs(cy - y)]){
-						left--;
-					}
-					left = cx - left;
-				}
-				right = Math.min(width()-1, cx + cx - left);
-				left = Math.max(0, left);
-				pos = left + y * width();
-				System.arraycopy(discoverable, pos, fieldOfView, pos, right - left + 1);
-			}
-		}
-
-		if (c instanceof SpiritHawk.HawkAlly && Dungeon.hero.pointsInTalent(Talent.EAGLE_EYE) >= 3){
-			int range = 1+(Dungeon.hero.pointsInTalent(Talent.EAGLE_EYE)-2);
-			for (Mob mob : mobs) {
-				int p = mob.pos;
-				if (!fieldOfView[p] && distance(c.pos, p) <= range) {
-					for (int i : PathFinder.NEIGHBOURS9) {
-						fieldOfView[mob.pos + i] = true;
-					}
-				}
-			}
-		}
-
-		//Currently only the hero can get mind vision or awareness
-		if (c.isAlive() && c == Dungeon.hero) {
-
-			if (heroMindFov == null || heroMindFov.length != length()){
-				heroMindFov = new boolean[length];
-			} else {
-				BArray.setFalse(heroMindFov);
-			}
-
-			Dungeon.hero.mindVisionEnemies.clear();
-			if (c.buff( MindVision.class ) != null) {
-				for (Mob mob : mobs) {
-					for (int i : PathFinder.NEIGHBOURS9) {
-						heroMindFov[mob.pos + i] = true;
-					}
-				}
-			} else if (((Hero) c).hasTalent(Talent.HEIGHTENED_SENSES)) {
-				Hero h = (Hero) c;
-				int range = 1+h.pointsInTalent(Talent.HEIGHTENED_SENSES);
-				for (Mob mob : mobs) {
-					int p = mob.pos;
-					if (!fieldOfView[p] && distance(c.pos, p) <= range) {
-						for (int i : PathFinder.NEIGHBOURS9) {
-							heroMindFov[mob.pos + i] = true;
-						}
-					}
-				}
-			}
-			
-			if (c.buff( Awareness.class ) != null) {
-				for (Heap heap : heaps.valueList()) {
-					int p = heap.pos;
-					for (int i : PathFinder.NEIGHBOURS9) heroMindFov[p+i] = true;
-				}
-			}
-
-			for (TalismanOfForesight.CharAwareness a : c.buffs(TalismanOfForesight.CharAwareness.class)){
-				Char ch = (Char) Actor.findById(a.charID);
-				if (ch == null || !ch.isAlive()) {
-					continue;
-				}
-				int p = ch.pos;
-				for (int i : PathFinder.NEIGHBOURS9) heroMindFov[p+i] = true;
-			}
-
-			for (TalismanOfForesight.HeapAwareness h : c.buffs(TalismanOfForesight.HeapAwareness.class)){
-				if (Dungeon.depth != h.depth || Dungeon.branch != h.branch) continue;
-				for (int i : PathFinder.NEIGHBOURS9) heroMindFov[h.pos+i] = true;
-			}
-
-			for (Mob m : mobs){
-				if (m instanceof WandOfWarding.Ward
-						|| m instanceof WandOfRegrowth.Lotus
-						|| m instanceof SpiritHawk.HawkAlly){
-					if (m.fieldOfView == null || m.fieldOfView.length != length()){
-						m.fieldOfView = new boolean[length()];
-						Dungeon.level.updateFieldOfView( m, m.fieldOfView );
-					}
-					BArray.or(heroMindFov, m.fieldOfView, heroMindFov);
-				}
-			}
-
-			for (RevealedArea a : c.buffs(RevealedArea.class)){
-				if (Dungeon.depth != a.depth || Dungeon.branch != a.branch) continue;
-				for (int i : PathFinder.NEIGHBOURS9) heroMindFov[a.pos+i] = true;
-			}
-
-			//set mind vision chars
-			for (Mob mob : mobs) {
-				if (heroMindFov[mob.pos] && !fieldOfView[mob.pos]){
-					Dungeon.hero.mindVisionEnemies.add(mob);
-				}
-			}
-
-			BArray.or(heroMindFov, fieldOfView, fieldOfView);
-
-		}
-
-		if (c == Dungeon.hero) {
-			for (Heap heap : heaps.valueList())
-				if (!heap.seen && fieldOfView[heap.pos])
-					heap.seen = true;
-		}
-
-	}
-
-	public boolean isLevelExplored( int depth ){
-		return false;
-	}
-	
-	public int distance( int a, int b ) {
-		int ax = a % width();
-		int ay = a / width();
-		int bx = b % width();
-		int by = b / width();
-		return Math.max( Math.abs( ax - bx ), Math.abs( ay - by ) );
-	}
-	
-	public boolean adjacent( int a, int b ) {
-		return distance( a, b ) == 1;
-	}
-	
-	//uses pythagorean theorum for true distance, as if there was no movement grid
-	public float trueDistance(int a, int b){
-		int ax = a % width();
-		int ay = a / width();
-		int bx = b % width();
-		int by = b / width();
-		return (float)Math.sqrt(Math.pow(Math.abs( ax - bx ), 2) + Math.pow(Math.abs( ay - by ), 2));
-	}
-
-	//returns true if the input is a valid tile within the level
-	public boolean insideMap( int tile ){
-				//top and bottom row and beyond
-		return !((tile < width || tile >= length - width) ||
-				//left and right column
-				(tile % width == 0 || tile % width == width-1));
-	}
-
-	public Point cellToPoint( int cell ){
-		return new Point(cell % width(), cell / width());
-	}
-
-	public int pointToCell( Point p ){
-		return p.x + p.y*width();
-	}
-	
-	public String tileName( int tile ) {
-		
-		switch (tile) {
-			case Terrain.CHASM:
-				return Messages.get(Level.class, "chasm_name");
-			case Terrain.EMPTY:
-			case Terrain.EMPTY_SP:
-			case Terrain.EMPTY_DECO:
-			case Terrain.SECRET_TRAP:
-				return Messages.get(Level.class, "floor_name");
-			case Terrain.GRASS:
-				return Messages.get(Level.class, "grass_name");
-			case Terrain.WATER:
-				return Messages.get(Level.class, "water_name");
-			case Terrain.WALL:
-			case Terrain.WALL_DECO:
-			case Terrain.SECRET_DOOR:
-				return Messages.get(Level.class, "wall_name");
-			case Terrain.DOOR:
-				return Messages.get(Level.class, "closed_door_name");
-			case Terrain.OPEN_DOOR:
-				return Messages.get(Level.class, "open_door_name");
-			case Terrain.ENTRANCE:
-				return Messages.get(Level.class, "entrace_name");
-			case Terrain.EXIT:
-				return Messages.get(Level.class, "exit_name");
-			case Terrain.EMBERS:
-				return Messages.get(Level.class, "embers_name");
-			case Terrain.FURROWED_GRASS:
-				return Messages.get(Level.class, "furrowed_grass_name");
-			case Terrain.LOCKED_DOOR:
-				return Messages.get(Level.class, "locked_door_name");
-			case Terrain.CRYSTAL_DOOR:
-				return Messages.get(Level.class, "crystal_door_name");
-			case Terrain.PEDESTAL:
-				return Messages.get(Level.class, "pedestal_name");
-			case Terrain.BARRICADE:
-				return Messages.get(Level.class, "barricade_name");
-			case Terrain.HIGH_GRASS:
-				return Messages.get(Level.class, "high_grass_name");
-			case Terrain.LOCKED_EXIT:
-				return Messages.get(Level.class, "locked_exit_name");
-			case Terrain.UNLOCKED_EXIT:
-				return Messages.get(Level.class, "unlocked_exit_name");
-			case Terrain.SIGN:
-				return Messages.get(Level.class, "sign_name");
-			case Terrain.WELL:
-				return Messages.get(Level.class, "well_name");
-			case Terrain.EMPTY_WELL:
-				return Messages.get(Level.class, "empty_well_name");
-			case Terrain.STATUE:
-			case Terrain.STATUE_SP:
-				return Messages.get(Level.class, "statue_name");
-			case Terrain.INACTIVE_TRAP:
-				return Messages.get(Level.class, "inactive_trap_name");
-			case Terrain.BOOKSHELF:
-				return Messages.get(Level.class, "bookshelf_name");
-			case Terrain.ALCHEMY:
-				return Messages.get(Level.class, "alchemy_name");
-			default:
-				return Messages.get(Level.class, "default_name");
-		}
-	}
-	
-	public String tileDesc( int tile ) {
-		
-		switch (tile) {
-			case Terrain.CHASM:
-				return Messages.get(Level.class, "chasm_desc");
-			case Terrain.WATER:
-				return Messages.get(Level.class, "water_desc");
-			case Terrain.ENTRANCE:
-				return Messages.get(Level.class, "entrance_desc");
-			case Terrain.EXIT:
-			case Terrain.UNLOCKED_EXIT:
-				return Messages.get(Level.class, "exit_desc");
-			case Terrain.EMBERS:
-				return Messages.get(Level.class, "embers_desc");
-			case Terrain.HIGH_GRASS:
-			case Terrain.FURROWED_GRASS:
-				return Messages.get(Level.class, "high_grass_desc");
-			case Terrain.LOCKED_DOOR:
-				return Messages.get(Level.class, "locked_door_desc");
-			case Terrain.CRYSTAL_DOOR:
-				return Messages.get(Level.class, "crystal_door_desc");
-			case Terrain.LOCKED_EXIT:
-				return Messages.get(Level.class, "locked_exit_desc");
-			case Terrain.BARRICADE:
-				return Messages.get(Level.class, "barricade_desc");
-			case Terrain.SIGN:
-				return Messages.get(Level.class, "sign_desc");
-			case Terrain.INACTIVE_TRAP:
-				return Messages.get(Level.class, "inactive_trap_desc");
-			case Terrain.STATUE:
-			case Terrain.STATUE_SP:
-				return Messages.get(Level.class, "statue_desc");
-			case Terrain.ALCHEMY:
-				return Messages.get(Level.class, "alchemy_desc");
-			case Terrain.EMPTY_WELL:
-				return Messages.get(Level.class, "empty_well_desc");
-			default:
-				return "";
-		}
-	}
+
+    public static enum Feeling {
+        NONE,
+        CHASM,
+        WATER,
+        GRASS,
+        DARK,
+        LARGE,
+        TRAPS,
+        SECRETS
+    }
+
+    protected int width;
+    protected int height;
+    protected int length;
+
+    protected static final float TIME_TO_RESPAWN = 50;
+
+    public int version;
+
+    public int[] map;
+    public boolean[] visited;
+    public boolean[] mapped;
+    public boolean[] discoverable;
+
+    public int viewDistance = Dungeon.isChallenged(Challenges.DARKNESS) ? 2 : 8;
+
+    public boolean[] heroFOV;
+
+    public boolean[] passable;
+    public boolean[] losBlocking;
+    public boolean[] flamable;
+    public boolean[] secret;
+    public boolean[] solid;
+    public boolean[] avoid;
+    public boolean[] water;
+    public boolean[] pit;
+
+    public boolean[] openSpace;
+
+    public Feeling feeling = Feeling.NONE;
+
+    public int entrance;
+    public int exit;
+
+    public ArrayList<LevelTransition> transitions;
+
+    // when a boss level has become locked.
+    public boolean locked = false;
+
+    public HashSet<Mob> mobs;
+    public SparseArray<Heap> heaps;
+    public HashMap<Class<? extends Blob>, Blob> blobs;
+    public SparseArray<Plant> plants;
+    public SparseArray<Trap> traps;
+    public HashSet<CustomTilemap> customTiles;
+    public HashSet<CustomTilemap> customWalls;
+
+    protected ArrayList<Item> itemsToSpawn = new ArrayList<>();
+
+    protected Group visuals;
+
+    public int color1 = 0x004400;
+    public int color2 = 0x88CC44;
+
+    private static final String VERSION = "version";
+    private static final String WIDTH = "width";
+    private static final String HEIGHT = "height";
+    private static final String MAP = "map";
+    private static final String VISITED = "visited";
+    private static final String MAPPED = "mapped";
+    private static final String TRANSITIONS = "transitions";
+    private static final String LOCKED = "locked";
+    private static final String HEAPS = "heaps";
+    private static final String PLANTS = "plants";
+    private static final String TRAPS = "traps";
+    private static final String CUSTOM_TILES = "customTiles";
+    private static final String CUSTOM_WALLS = "customWalls";
+    private static final String MOBS = "mobs";
+    private static final String BLOBS = "blobs";
+    private static final String FEELING = "feeling";
+
+    public void create() {
+
+        Random.pushGenerator(Dungeon.seedCurDepth());
+
+        // TODO maybe just make this part of RegularLevel?
+        if (!Dungeon.bossLevel() && Dungeon.branch == 0) {
+
+            addItemToSpawn(Generator.random(Generator.Category.FOOD));
+
+            if (Dungeon.isChallenged(Challenges.DARKNESS)) {
+                addItemToSpawn(new Torch());
+            }
+
+            if (Dungeon.posNeeded()) {
+                addItemToSpawn(new PotionOfStrength());
+                Dungeon.LimitedDrops.STRENGTH_POTIONS.count++;
+            }
+            if (Dungeon.souNeeded()) {
+                addItemToSpawn(new ScrollOfUpgrade());
+                Dungeon.LimitedDrops.UPGRADE_SCROLLS.count++;
+            }
+            if (Dungeon.asNeeded()) {
+                addItemToSpawn(new Stylus());
+                Dungeon.LimitedDrops.ARCANE_STYLI.count++;
+            }
+            // one scroll of transmutation is guaranteed to spawn somewhere on chapter 2-4
+            int enchChapter = (int) ((Dungeon.seed / 10) % 3) + 1;
+            if (Dungeon.depth / 5 == enchChapter &&
+                    Dungeon.seed % 4 + 1 == Dungeon.depth % 5) {
+                addItemToSpawn(new StoneOfEnchantment());
+            }
+
+            if (Dungeon.depth == ((Dungeon.seed % 3) + 1)) {
+                addItemToSpawn(new StoneOfIntuition());
+            }
+
+            if (Dungeon.depth > 1) {
+                // 50% chance of getting a level feeling
+                // ~7.15% chance for each feeling
+                switch (Random.Int(14)) {
+                    case 0:
+                        feeling = Feeling.CHASM;
+                        break;
+                    case 1:
+                        feeling = Feeling.WATER;
+                        break;
+                    case 2:
+                        feeling = Feeling.GRASS;
+                        break;
+                    case 3:
+                        feeling = Feeling.DARK;
+                        addItemToSpawn(new Torch());
+                        viewDistance = Math.round(viewDistance / 2f);
+                        break;
+                    case 4:
+                        feeling = Feeling.LARGE;
+                        addItemToSpawn(Generator.random(Generator.Category.FOOD));
+                        // add a second torch to help with the larger floor
+                        if (Dungeon.isChallenged(Challenges.DARKNESS)) {
+                            addItemToSpawn(new Torch());
+                        }
+                        break;
+                    case 5:
+                        feeling = Feeling.TRAPS;
+                        break;
+                    case 6:
+                        feeling = Feeling.SECRETS;
+                        break;
+                }
+            }
+        }
+
+        do {
+            width = height = length = 0;
+
+            transitions = new ArrayList<>();
+
+            mobs = new HashSet<>();
+            heaps = new SparseArray<>();
+            blobs = new HashMap<>();
+            plants = new SparseArray<>();
+            traps = new SparseArray<>();
+            customTiles = new HashSet<>();
+            customWalls = new HashSet<>();
+
+        } while (!build());
+
+        buildFlagMaps();
+        cleanWalls();
+
+        createMobs();
+        createItems();
+
+        Random.popGenerator();
+    }
+
+    public void setSize(int w, int h) {
+
+        width = w;
+        height = h;
+        length = w * h;
+
+        map = new int[length];
+        Arrays.fill(map, feeling == Level.Feeling.CHASM ? Terrain.CHASM : Terrain.WALL);
+
+        visited = new boolean[length];
+        mapped = new boolean[length];
+
+        heroFOV = new boolean[length];
+
+        passable = new boolean[length];
+        losBlocking = new boolean[length];
+        flamable = new boolean[length];
+        secret = new boolean[length];
+        solid = new boolean[length];
+        avoid = new boolean[length];
+        water = new boolean[length];
+        pit = new boolean[length];
+
+        openSpace = new boolean[length];
+
+        PathFinder.setMapSize(w, h);
+    }
+
+    public void reset() {
+
+        for (Mob mob : mobs.toArray(new Mob[0])) {
+            if (!mob.reset()) {
+                mobs.remove(mob);
+            }
+        }
+        createMobs();
+    }
+
+    public void playLevelMusic() {
+        // do nothing by default
+    }
+
+    @Override
+    public void restoreFromBundle(Bundle bundle) {
+
+        version = bundle.getInt(VERSION);
+
+        // saves from before v1.2.3 are not supported
+        if (version < ShatteredPixelDungeon.v1_2_3) {
+            throw new RuntimeException("old save");
+        }
+
+        setSize(bundle.getInt(WIDTH), bundle.getInt(HEIGHT));
+
+        mobs = new HashSet<>();
+        heaps = new SparseArray<>();
+        blobs = new HashMap<>();
+        plants = new SparseArray<>();
+        traps = new SparseArray<>();
+        customTiles = new HashSet<>();
+        customWalls = new HashSet<>();
+
+        map = bundle.getIntArray(MAP);
+
+        visited = bundle.getBooleanArray(VISITED);
+        mapped = bundle.getBooleanArray(MAPPED);
+
+        transitions = new ArrayList<>();
+        if (bundle.contains(TRANSITIONS)) {
+            for (Bundlable b : bundle.getCollection(TRANSITIONS)) {
+                transitions.add((LevelTransition) b);
+            }
+            // pre-1.3.0 saves, converts old entrance/exit to new transitions
+        } else {
+            if (bundle.contains("entrance")) {
+                transitions.add(new LevelTransition(
+                        this,
+                        bundle.getInt("entrance"),
+                        Dungeon.depth == 1 ? LevelTransition.Type.SURFACE : LevelTransition.Type.REGULAR_ENTRANCE));
+            }
+            if (bundle.contains("exit")) {
+                transitions.add(new LevelTransition(this, bundle.getInt("exit"), LevelTransition.Type.REGULAR_EXIT));
+            }
+        }
+
+        locked = bundle.getBoolean(LOCKED);
+
+        Collection<Bundlable> collection = bundle.getCollection(HEAPS);
+        for (Bundlable h : collection) {
+            Heap heap = (Heap) h;
+            if (!heap.isEmpty())
+                heaps.put(heap.pos, heap);
+        }
+
+        collection = bundle.getCollection(PLANTS);
+        for (Bundlable p : collection) {
+            Plant plant = (Plant) p;
+            plants.put(plant.pos, plant);
+        }
+
+        collection = bundle.getCollection(TRAPS);
+        for (Bundlable p : collection) {
+            Trap trap = (Trap) p;
+            traps.put(trap.pos, trap);
+        }
+
+        collection = bundle.getCollection(CUSTOM_TILES);
+        for (Bundlable p : collection) {
+            CustomTilemap vis = (CustomTilemap) p;
+            customTiles.add(vis);
+        }
+
+        collection = bundle.getCollection(CUSTOM_WALLS);
+        for (Bundlable p : collection) {
+            CustomTilemap vis = (CustomTilemap) p;
+            customWalls.add(vis);
+        }
+
+        collection = bundle.getCollection(MOBS);
+        for (Bundlable m : collection) {
+            Mob mob = (Mob) m;
+            if (mob != null) {
+                mobs.add(mob);
+            }
+        }
+
+        collection = bundle.getCollection(BLOBS);
+        for (Bundlable b : collection) {
+            Blob blob = (Blob) b;
+            blobs.put(blob.getClass(), blob);
+        }
+
+        feeling = bundle.getEnum(FEELING, Feeling.class);
+        if (feeling == Feeling.DARK)
+            viewDistance = Math.round(viewDistance / 2f);
+
+        if (bundle.contains("mobs_to_spawn")) {
+            for (Class<? extends Mob> mob : bundle.getClassArray("mobs_to_spawn")) {
+                if (mob != null)
+                    mobsToSpawn.add(mob);
+            }
+        }
+
+        if (bundle.contains("respawner")) {
+            respawner = (Respawner) bundle.get("respawner");
+        }
+
+        buildFlagMaps();
+        cleanWalls();
+
+    }
+
+    @Override
+    public void storeInBundle(Bundle bundle) {
+        bundle.put(VERSION, Game.versionCode);
+        bundle.put(WIDTH, width);
+        bundle.put(HEIGHT, height);
+        bundle.put(MAP, map);
+        bundle.put(VISITED, visited);
+        bundle.put(MAPPED, mapped);
+        bundle.put(TRANSITIONS, transitions);
+        bundle.put(LOCKED, locked);
+        bundle.put(HEAPS, heaps.valueList());
+        bundle.put(PLANTS, plants.valueList());
+        bundle.put(TRAPS, traps.valueList());
+        bundle.put(CUSTOM_TILES, customTiles);
+        bundle.put(CUSTOM_WALLS, customWalls);
+        bundle.put(MOBS, mobs);
+        bundle.put(BLOBS, blobs.values());
+        bundle.put(FEELING, feeling);
+        bundle.put("mobs_to_spawn", mobsToSpawn.toArray(new Class[0]));
+        bundle.put("respawner", respawner);
+    }
+
+    public int tunnelTile() {
+        return feeling == Feeling.CHASM ? Terrain.EMPTY_SP : Terrain.EMPTY;
+    }
+
+    public int width() {
+        return width;
+    }
+
+    public int height() {
+        return height;
+    }
+
+    public int length() {
+        return length;
+    }
+
+    public String tilesTex() {
+        return null;
+    }
+
+    public String waterTex() {
+        return null;
+    }
+
+    abstract protected boolean build();
+
+    private ArrayList<Class<? extends Mob>> mobsToSpawn = new ArrayList<>();
+
+    public Mob createMob() {
+        if (mobsToSpawn == null || mobsToSpawn.isEmpty()) {
+            mobsToSpawn = Bestiary.getMobRotation(Dungeon.depth);
+        }
+
+        Mob m = Reflection.newInstance(mobsToSpawn.remove(0));
+        ChampionEnemy.rollForChampion(m);
+        return m;
+    }
+
+    abstract protected void createMobs();
+
+    abstract protected void createItems();
+
+    public int entrance() {
+        LevelTransition l = getTransition(null);
+        if (l != null) {
+            return l.cell();
+        }
+        return 0;
+    }
+
+    public int exit() {
+        LevelTransition l = getTransition(LevelTransition.Type.REGULAR_EXIT);
+        if (l != null) {
+            return l.cell();
+        }
+        return 0;
+    }
+
+    public LevelTransition getTransition(LevelTransition.Type type) {
+        if (transitions.isEmpty()) {
+            return null;
+        }
+        for (LevelTransition transition : transitions) {
+            // if we don't specify a type, prefer to return any entrance
+            if (type == null &&
+                    (transition.type == LevelTransition.Type.REGULAR_ENTRANCE
+                            || transition.type == LevelTransition.Type.SURFACE)) {
+                return transition;
+            } else if (transition.type == type) {
+                return transition;
+            }
+        }
+        return type != null ? getTransition(null) : transitions.get(0);
+    }
+
+    public LevelTransition getTransition(int cell) {
+        for (LevelTransition transition : transitions) {
+            if (transition.inside(cell)) {
+                return transition;
+            }
+        }
+        return null;
+    }
+
+    // some buff effects have special logic or are cancelled from the hero before
+    // transitioning levels
+    public static void beforeTransition() {
+
+        // time freeze effects need to resolve their pressed cells before transitioning
+        TimekeepersHourglass.timeFreeze timeFreeze = Dungeon.hero.buff(TimekeepersHourglass.timeFreeze.class);
+        if (timeFreeze != null)
+            timeFreeze.disarmPresses();
+        Swiftthistle.TimeBubble timeBubble = Dungeon.hero.buff(Swiftthistle.TimeBubble.class);
+        if (timeBubble != null)
+            timeBubble.disarmPresses();
+
+        // iron stomach does not persist through chasm falling
+        Talent.WarriorFoodImmunity foodImmune = Dungeon.hero.buff(Talent.WarriorFoodImmunity.class);
+        if (foodImmune != null)
+            foodImmune.detach();
+
+        // spend the hero's partial turns, so the hero cannot take partial turns between
+        // floors
+        Dungeon.hero.spendToWhole();
+        for (Char ch : Actor.chars()) {
+            // also adjust any mobs that are now ahead of the hero due to this
+            if (ch.cooldown() < Dungeon.hero.cooldown()) {
+                ch.spendToWhole();
+            }
+        }
+    }
+
+    public void seal() {
+        if (!locked) {
+            locked = true;
+            Buff.affect(Dungeon.hero, LockedFloor.class);
+        }
+    }
+
+    public void unseal() {
+        if (locked) {
+            locked = false;
+            if (Dungeon.hero.buff(LockedFloor.class) != null) {
+                Dungeon.hero.buff(LockedFloor.class).detach();
+            }
+        }
+    }
+
+    public ArrayList<Item> getItemsToPreserveFromSealedResurrect() {
+        ArrayList<Item> items = new ArrayList<>();
+        for (Heap h : heaps.valueList()) {
+            if (h.type == Heap.Type.HEAP)
+                items.addAll(h.items);
+        }
+        for (Mob m : mobs) {
+            for (PinCushion b : m.buffs(PinCushion.class)) {
+                items.addAll(b.getStuckItems());
+            }
+        }
+        for (HeavyBoomerang.CircleBack b : Dungeon.hero.buffs(HeavyBoomerang.CircleBack.class)) {
+            if (b.activeDepth() == Dungeon.depth)
+                items.add(b.cancel());
+        }
+        return items;
+    }
+
+    public Group addVisuals() {
+        if (visuals == null || visuals.parent == null) {
+            visuals = new Group();
+        } else {
+            visuals.clear();
+            visuals.camera = null;
+        }
+        for (int i = 0; i < length(); i++) {
+            if (pit[i]) {
+                visuals.add(new WindParticle.Wind(i));
+                if (i >= width() && water[i - width()]) {
+                    visuals.add(new FlowParticle.Flow(i - width()));
+                }
+            }
+        }
+        return visuals;
+    }
+
+    public int mobLimit() {
+        return 0;
+    }
+
+    public int mobCount() {
+        float count = 0;
+        for (Mob mob : Dungeon.level.mobs.toArray(new Mob[0])) {
+            if (mob.alignment == Char.Alignment.ENEMY && !mob.properties().contains(Char.Property.MINIBOSS)) {
+                count += mob.spawningWeight();
+            }
+        }
+        return Math.round(count);
+    }
+
+    public Mob findMob(int pos) {
+        for (Mob mob : mobs) {
+            if (mob.pos == pos) {
+                return mob;
+            }
+        }
+        return null;
+    }
+
+    private Respawner respawner;
+
+    public Actor addRespawner() {
+        if (respawner == null) {
+            respawner = new Respawner();
+            Actor.addDelayed(respawner, respawnCooldown());
+        } else {
+            Actor.add(respawner);
+            if (respawner.cooldown() > respawnCooldown()) {
+                respawner.resetCooldown();
+            }
+        }
+        return respawner;
+    }
+
+    public static class Respawner extends Actor {
+        {
+            actPriority = BUFF_PRIO; // as if it were a buff.
+        }
+
+        @Override
+        protected boolean act() {
+
+            if (Dungeon.level.mobCount() < Dungeon.level.mobLimit()) {
+
+                if (Dungeon.level.spawnMob(12)) {
+                    spend(Dungeon.level.respawnCooldown());
+                } else {
+                    // try again in 1 turn
+                    spend(TICK);
+                }
+
+            } else {
+                spend(Dungeon.level.respawnCooldown());
+            }
+
+            return true;
+        }
+
+        protected void resetCooldown() {
+            spend(-cooldown());
+            spend(Dungeon.level.respawnCooldown());
+        }
+    }
+
+    public float respawnCooldown() {
+        if (Statistics.amuletObtained) {
+            if (Dungeon.depth == 1) {
+                // very fast spawns on floor 1! 0/2/4/6/8/10/12, etc.
+                return (Dungeon.level.mobCount()) * (TIME_TO_RESPAWN / 25f);
+            } else {
+                // respawn time is 5/5/10/15/20/25/25, etc.
+                return Math.round(GameMath.gate(TIME_TO_RESPAWN / 10f,
+                        Dungeon.level.mobCount() * (TIME_TO_RESPAWN / 10f), TIME_TO_RESPAWN / 2f));
+            }
+        } else if (Dungeon.level.feeling == Feeling.DARK) {
+            return 2 * TIME_TO_RESPAWN / 3f;
+        } else {
+            return TIME_TO_RESPAWN;
+        }
+    }
+
+    public boolean spawnMob(int disLimit) {
+        PathFinder.buildDistanceMap(Dungeon.hero.pos, BArray.or(passable, avoid, null));
+
+        Mob mob = createMob();
+        mob.state = mob.WANDERING;
+        int tries = 30;
+        do {
+            mob.pos = randomRespawnCell(mob);
+            tries--;
+        } while ((mob.pos == -1 || PathFinder.distance[mob.pos] < disLimit) && tries > 0);
+
+        if (Dungeon.hero.isAlive() && mob.pos != -1 && PathFinder.distance[mob.pos] >= disLimit) {
+            GameScene.add(mob);
+            if (!mob.buffs(ChampionEnemy.class).isEmpty()) {
+                GLog.w(Messages.get(ChampionEnemy.class, "warn"));
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public int randomRespawnCell(Char ch) {
+        int cell;
+        int count = 0;
+        do {
+
+            if (++count > 30) {
+                return -1;
+            }
+
+            cell = Random.Int(length());
+
+        } while ((Dungeon.level == this && heroFOV[cell])
+                || !passable[cell]
+                || (Char.hasProp(ch, Char.Property.LARGE) && !openSpace[cell])
+                || Actor.findChar(cell) != null);
+        return cell;
+    }
+
+    public int randomDestination(Char ch) {
+        int cell;
+        do {
+            cell = Random.Int(length());
+        } while (!passable[cell]
+                || (Char.hasProp(ch, Char.Property.LARGE) && !openSpace[cell]));
+        return cell;
+    }
+
+    public void addItemToSpawn(Item item) {
+        if (item != null) {
+            itemsToSpawn.add(item);
+        }
+    }
+
+    public Item findPrizeItem() {
+        return findPrizeItem(null);
+    }
+
+    public Item findPrizeItem(Class<? extends Item> match) {
+        if (itemsToSpawn.size() == 0)
+            return null;
+
+        if (match == null) {
+            Item item = Random.element(itemsToSpawn);
+            itemsToSpawn.remove(item);
+            return item;
+        }
+
+        for (Item item : itemsToSpawn) {
+            if (match.isInstance(item)) {
+                itemsToSpawn.remove(item);
+                return item;
+            }
+        }
+
+        return null;
+    }
+
+    public void buildFlagMaps() {
+
+        for (int i = 0; i < length(); i++) {
+            int flags = Terrain.flags[map[i]];
+            passable[i] = (flags & Terrain.PASSABLE) != 0;
+            losBlocking[i] = (flags & Terrain.LOS_BLOCKING) != 0;
+            flamable[i] = (flags & Terrain.FLAMABLE) != 0;
+            secret[i] = (flags & Terrain.SECRET) != 0;
+            solid[i] = (flags & Terrain.SOLID) != 0;
+            avoid[i] = (flags & Terrain.AVOID) != 0;
+            water[i] = (flags & Terrain.LIQUID) != 0;
+            pit[i] = (flags & Terrain.PIT) != 0;
+        }
+
+        for (Blob b : blobs.values()) {
+            b.onBuildFlagMaps(this);
+        }
+
+        int lastRow = length() - width();
+        for (int i = 0; i < width(); i++) {
+            passable[i] = avoid[i] = false;
+            losBlocking[i] = solid[i] = true;
+            passable[lastRow + i] = avoid[lastRow + i] = false;
+            losBlocking[lastRow + i] = solid[lastRow + i] = true;
+        }
+        for (int i = width(); i < lastRow; i += width()) {
+            passable[i] = avoid[i] = false;
+            losBlocking[i] = solid[i] = true;
+            passable[i + width() - 1] = avoid[i + width() - 1] = false;
+            losBlocking[i + width() - 1] = solid[i + width() - 1] = true;
+        }
+
+        // an open space is large enough to fit large mobs. A space is open when it is
+        // not solid
+        // and there is an open corner with both adjacent cells opens
+        for (int i = 0; i < length(); i++) {
+            if (solid[i]) {
+                openSpace[i] = false;
+            } else {
+                for (int j = 1; j < PathFinder.CIRCLE8.length; j += 2) {
+                    if (solid[i + PathFinder.CIRCLE8[j]]) {
+                        openSpace[i] = false;
+                    } else if (!solid[i + PathFinder.CIRCLE8[(j + 1) % 8]]
+                            && !solid[i + PathFinder.CIRCLE8[(j + 2) % 8]]) {
+                        openSpace[i] = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+    }
+
+    public void destroy(int pos) {
+        // if raw tile type is flammable or empty
+        int terr = map[pos];
+        if (terr == Terrain.EMPTY || terr == Terrain.EMPTY_DECO
+                || (Terrain.flags[map[pos]] & Terrain.FLAMABLE) != 0) {
+            set(pos, Terrain.EMBERS);
+        }
+        Blob web = blobs.get(Web.class);
+        if (web != null) {
+            web.clear(pos);
+        }
+    }
+
+    public void cleanWalls() {
+        if (discoverable == null || discoverable.length != length) {
+            discoverable = new boolean[length()];
+        }
+
+        for (int i = 0; i < length(); i++) {
+
+            boolean d = false;
+
+            for (int j = 0; j < PathFinder.NEIGHBOURS9.length; j++) {
+                int n = i + PathFinder.NEIGHBOURS9[j];
+                if (n >= 0 && n < length() && map[n] != Terrain.WALL && map[n] != Terrain.WALL_DECO) {
+                    d = true;
+                    break;
+                }
+            }
+
+            discoverable[i] = d;
+        }
+    }
+
+    public static void set(int cell, int terrain) {
+        set(cell, terrain, Dungeon.level);
+    }
+
+    public static void set(int cell, int terrain, Level level) {
+        Painter.set(level, cell, terrain);
+
+        if (terrain != Terrain.TRAP && terrain != Terrain.SECRET_TRAP && terrain != Terrain.INACTIVE_TRAP) {
+            level.traps.remove(cell);
+        }
+
+        int flags = Terrain.flags[terrain];
+        level.passable[cell] = (flags & Terrain.PASSABLE) != 0;
+        level.losBlocking[cell] = (flags & Terrain.LOS_BLOCKING) != 0;
+        level.flamable[cell] = (flags & Terrain.FLAMABLE) != 0;
+        level.secret[cell] = (flags & Terrain.SECRET) != 0;
+        level.solid[cell] = (flags & Terrain.SOLID) != 0;
+        level.avoid[cell] = (flags & Terrain.AVOID) != 0;
+        level.pit[cell] = (flags & Terrain.PIT) != 0;
+        level.water[cell] = terrain == Terrain.WATER;
+
+        for (int i : PathFinder.NEIGHBOURS9) {
+            i = cell + i;
+            if (level.solid[i]) {
+                level.openSpace[i] = false;
+            } else {
+                for (int j = 1; j < PathFinder.CIRCLE8.length; j += 2) {
+                    if (level.solid[i + PathFinder.CIRCLE8[j]]) {
+                        level.openSpace[i] = false;
+                    } else if (!level.solid[i + PathFinder.CIRCLE8[(j + 1) % 8]]
+                            && !level.solid[i + PathFinder.CIRCLE8[(j + 2) % 8]]) {
+                        level.openSpace[i] = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    public Heap drop(Item item, int cell, boolean triggerAutoPickup) {
+        Heap result = drop(item, cell);
+        if (triggerAutoPickup) {
+            System.out.println("Attempting to auto-loot item " + item.name());
+            Dungeon.hero.actPickUp(new PickUp(heaps.get(cell).pos, true));
+        }
+        return result;
+    }
+
+    public Heap drop(Item item, int cell) {
+
+        if (item == null || Challenges.isItemBlocked(item)) {
+
+            // create a dummy heap, give it a dummy sprite, don't add it to the game, and
+            // return it.
+            // effectively nullifies whatever the logic calling this wants to do, including
+            // dropping items.
+            Heap heap = new Heap();
+            ItemSprite sprite = heap.sprite = new ItemSprite();
+            sprite.link(heap);
+            return heap;
+
+        }
+
+        Heap heap = heaps.get(cell);
+        if (heap == null) {
+
+            heap = new Heap();
+            heap.seen = Dungeon.level == this && heroFOV[cell];
+            heap.pos = cell;
+            heap.drop(item);
+            if (map[cell] == Terrain.CHASM || (Dungeon.level != null && pit[cell])) {
+                Dungeon.dropToChasm(item);
+                GameScene.discard(heap);
+            } else {
+                heaps.put(cell, heap);
+                GameScene.add(heap);
+            }
+
+        } else if (heap.type == Heap.Type.LOCKED_CHEST || heap.type == Heap.Type.CRYSTAL_CHEST) {
+
+            int n;
+            do {
+                n = cell + PathFinder.NEIGHBOURS8[Random.Int(8)];
+            } while (!passable[n] && !avoid[n]);
+            return drop(item, n);
+
+        } else {
+            heap.drop(item);
+        }
+
+        if (Dungeon.level != null && ShatteredPixelDungeon.scene() instanceof GameScene) {
+            pressCell(cell);
+        }
+
+        return heap;
+    }
+
+    public Plant plant(Plant.Seed seed, int pos) {
+
+        if (Dungeon.isChallenged(Challenges.NO_HERBALISM)) {
+            return null;
+        }
+
+        Plant plant = plants.get(pos);
+        if (plant != null) {
+            plant.wither();
+        }
+
+        if (map[pos] == Terrain.HIGH_GRASS ||
+                map[pos] == Terrain.FURROWED_GRASS ||
+                map[pos] == Terrain.EMPTY ||
+                map[pos] == Terrain.EMBERS ||
+                map[pos] == Terrain.EMPTY_DECO) {
+            set(pos, Terrain.GRASS, this);
+            GameScene.updateMap(pos);
+        }
+
+        plant = seed.couch(pos, this);
+        plants.put(pos, plant);
+
+        GameScene.plantSeed(pos);
+
+        for (Char ch : Actor.chars()) {
+            if (ch instanceof WandOfRegrowth.Lotus
+                    && ((WandOfRegrowth.Lotus) ch).inRange(pos)
+                    && Actor.findChar(pos) != null) {
+                plant.trigger();
+                return null;
+            }
+        }
+
+        return plant;
+    }
+
+    public void uproot(int pos) {
+        plants.remove(pos);
+        GameScene.updateMap(pos);
+    }
+
+    public Trap setTrap(Trap trap, int pos) {
+        Trap existingTrap = traps.get(pos);
+        if (existingTrap != null) {
+            traps.remove(pos);
+        }
+        trap.set(pos);
+        traps.put(pos, trap);
+        GameScene.updateMap(pos);
+        return trap;
+    }
+
+    public void disarmTrap(int pos) {
+        set(pos, Terrain.INACTIVE_TRAP);
+        GameScene.updateMap(pos);
+    }
+
+    public void discover(int cell) {
+        set(cell, Terrain.discover(map[cell]));
+        Trap trap = traps.get(cell);
+        if (trap != null)
+            trap.reveal();
+        GameScene.updateMap(cell);
+    }
+
+    public boolean setCellToWater(boolean includeTraps, int cell) {
+        Point p = cellToPoint(cell);
+
+        // if a custom tilemap is over that cell, don't put water there
+        for (CustomTilemap cust : customTiles) {
+            Point custPoint = new Point(p);
+            custPoint.x -= cust.tileX;
+            custPoint.y -= cust.tileY;
+            if (custPoint.x >= 0 && custPoint.y >= 0
+                    && custPoint.x < cust.tileW && custPoint.y < cust.tileH) {
+                if (cust.image(custPoint.x, custPoint.y) != null) {
+                    return false;
+                }
+            }
+        }
+
+        int terr = map[cell];
+        if (terr == Terrain.EMPTY || terr == Terrain.GRASS ||
+                terr == Terrain.EMBERS || terr == Terrain.EMPTY_SP ||
+                terr == Terrain.HIGH_GRASS || terr == Terrain.FURROWED_GRASS
+                || terr == Terrain.EMPTY_DECO) {
+            set(cell, Terrain.WATER);
+            GameScene.updateMap(cell);
+            return true;
+        } else if (includeTraps && (terr == Terrain.SECRET_TRAP ||
+                terr == Terrain.TRAP || terr == Terrain.INACTIVE_TRAP)) {
+            set(cell, Terrain.WATER);
+            Dungeon.level.traps.remove(cell);
+            GameScene.updateMap(cell);
+            return true;
+        }
+
+        return false;
+    }
+
+    public int fallCell(boolean fallIntoPit) {
+        int result;
+        do {
+            result = randomRespawnCell(null);
+            if (result == -1)
+                return -1;
+        } while (traps.get(result) != null
+                || findMob(result) != null);
+        return result;
+    }
+
+    public void occupyCell(Char ch) {
+        if (!ch.isImmune(Web.class) && Blob.volumeAt(ch.pos, Web.class) > 0) {
+            blobs.get(Web.class).clear(ch.pos);
+            Web.affectChar(ch);
+        }
+
+        if (!ch.flying) {
+
+            if ((map[ch.pos] == Terrain.GRASS || map[ch.pos] == Terrain.EMBERS)
+                    && ch == Dungeon.hero && Dungeon.hero.hasTalent(Talent.REJUVENATING_STEPS)
+                    && ch.buff(Talent.RejuvenatingStepsCooldown.class) == null) {
+
+                if (!Regeneration.regenOn()) {
+                    set(ch.pos, Terrain.FURROWED_GRASS);
+                } else if (ch.buff(Talent.RejuvenatingStepsFurrow.class) != null
+                        && ch.buff(Talent.RejuvenatingStepsFurrow.class).count() >= 200) {
+                    set(ch.pos, Terrain.FURROWED_GRASS);
+                } else {
+                    set(ch.pos, Terrain.HIGH_GRASS);
+                    Buff.count(ch, Talent.RejuvenatingStepsFurrow.class,
+                            3 - Dungeon.hero.pointsInTalent(Talent.REJUVENATING_STEPS));
+                }
+                GameScene.updateMap(ch.pos);
+                Buff.affect(ch, Talent.RejuvenatingStepsCooldown.class,
+                        15f - 5f * Dungeon.hero.pointsInTalent(Talent.REJUVENATING_STEPS));
+            }
+
+            if (pit[ch.pos]) {
+                if (ch == Dungeon.hero) {
+                    Chasm.heroFall(ch.pos);
+                } else if (ch instanceof Mob) {
+                    Chasm.mobFall((Mob) ch);
+                }
+                return;
+            }
+
+            // characters which are not the hero or a sheep 'soft' press cells
+            pressCell(ch.pos, ch instanceof Hero || ch instanceof Sheep);
+        } else {
+            if (map[ch.pos] == Terrain.DOOR) {
+                Door.enter(ch.pos);
+            }
+        }
+
+        if (ch.isAlive() && ch instanceof Piranha && !water[ch.pos]) {
+            ((Piranha) ch).dieOnLand();
+        }
+    }
+
+    // public method for forcing the hard press of a cell. e.g. when an item lands
+    // on it
+    public void pressCell(int cell) {
+        pressCell(cell, true);
+    }
+
+    // a 'soft' press ignores hidden traps
+    // a 'hard' press triggers all things
+    private void pressCell(int cell, boolean hard) {
+
+        Trap trap = null;
+
+        switch (map[cell]) {
+
+            case Terrain.SECRET_TRAP:
+                if (hard) {
+                    trap = traps.get(cell);
+                    GLog.i(Messages.get(Level.class, "hidden_trap", trap.name()));
+                }
+                break;
+
+            case Terrain.TRAP:
+                trap = traps.get(cell);
+                break;
+
+            case Terrain.HIGH_GRASS:
+            case Terrain.FURROWED_GRASS:
+                HighGrass.trample(this, cell);
+                break;
+
+            case Terrain.WELL:
+                WellWater.affectCell(cell);
+                break;
+
+            case Terrain.DOOR:
+                Door.enter(cell);
+                break;
+        }
+
+        TimekeepersHourglass.timeFreeze timeFreeze = Dungeon.hero.buff(TimekeepersHourglass.timeFreeze.class);
+
+        Swiftthistle.TimeBubble bubble = Dungeon.hero.buff(Swiftthistle.TimeBubble.class);
+
+        if (trap != null) {
+            if (bubble != null) {
+                Sample.INSTANCE.play(Assets.Sounds.TRAP);
+                discover(cell);
+                bubble.setDelayedPress(cell);
+
+            } else if (timeFreeze != null) {
+                Sample.INSTANCE.play(Assets.Sounds.TRAP);
+                discover(cell);
+                timeFreeze.setDelayedPress(cell);
+
+            } else {
+                if (Dungeon.hero.pos == cell) {
+                    Dungeon.hero.interrupt();
+                }
+                trap.trigger();
+
+            }
+        }
+
+        Plant plant = plants.get(cell);
+        if (plant != null) {
+            if (bubble != null) {
+                Sample.INSTANCE.play(Assets.Sounds.TRAMPLE, 1, Random.Float(0.96f, 1.05f));
+                bubble.setDelayedPress(cell);
+
+            } else if (timeFreeze != null) {
+                Sample.INSTANCE.play(Assets.Sounds.TRAMPLE, 1, Random.Float(0.96f, 1.05f));
+                timeFreeze.setDelayedPress(cell);
+
+            } else {
+                plant.trigger();
+
+            }
+        }
+
+        if (hard && Blob.volumeAt(cell, Web.class) > 0) {
+            blobs.get(Web.class).clear(cell);
+        }
+    }
+
+    private static boolean[] heroMindFov;
+
+    private static boolean[] modifiableBlocking;
+
+    public void updateFieldOfView(Char c, boolean[] fieldOfView) {
+
+        int cx = c.pos % width();
+        int cy = c.pos / width();
+
+        boolean sighted = c.buff(Blindness.class) == null && c.buff(Shadows.class) == null
+                && c.buff(TimekeepersHourglass.timeStasis.class) == null && c.isAlive();
+        if (sighted) {
+            boolean[] blocking = null;
+
+            if (modifiableBlocking == null || modifiableBlocking.length != Dungeon.level.losBlocking.length) {
+                modifiableBlocking = new boolean[Dungeon.level.losBlocking.length];
+            }
+
+            if ((c instanceof Hero && ((Hero) c).subClass == HeroSubClass.WARDEN)
+                    || c instanceof YogFist.SoiledFist) {
+                if (blocking == null) {
+                    System.arraycopy(Dungeon.level.losBlocking, 0, modifiableBlocking, 0, modifiableBlocking.length);
+                    blocking = modifiableBlocking;
+                }
+                for (int i = 0; i < blocking.length; i++) {
+                    if (blocking[i] && (Dungeon.level.map[i] == Terrain.HIGH_GRASS
+                            || Dungeon.level.map[i] == Terrain.FURROWED_GRASS)) {
+                        blocking[i] = false;
+                    }
+                }
+            }
+
+            if (c.alignment != Char.Alignment.ALLY
+                    && Dungeon.level.blobs.containsKey(SmokeScreen.class)
+                    && Dungeon.level.blobs.get(SmokeScreen.class).volume > 0) {
+                if (blocking == null) {
+                    System.arraycopy(Dungeon.level.losBlocking, 0, modifiableBlocking, 0, modifiableBlocking.length);
+                    blocking = modifiableBlocking;
+                }
+                Blob s = Dungeon.level.blobs.get(SmokeScreen.class);
+                for (int i = 0; i < blocking.length; i++) {
+                    if (!blocking[i] && s.cur[i] > 0) {
+                        blocking[i] = true;
+                    }
+                }
+            }
+
+            if (blocking == null) {
+                blocking = Dungeon.level.losBlocking;
+            }
+
+            int viewDist = c.viewDistance;
+            if (c instanceof Hero) {
+                viewDist *= 1f + 0.25f * ((Hero) c).pointsInTalent(Talent.FARSIGHT);
+            }
+
+            ShadowCaster.castShadow(cx, cy, fieldOfView, blocking, viewDist);
+        } else {
+            BArray.setFalse(fieldOfView);
+        }
+
+        int sense = 1;
+        // Currently only the hero can get mind vision
+        if (c.isAlive() && c == Dungeon.hero) {
+            for (Buff b : c.buffs(MindVision.class)) {
+                sense = Math.max(((MindVision) b).distance, sense);
+            }
+            if (c.buff(MagicalSight.class) != null) {
+                sense = Math.max(MagicalSight.DISTANCE, sense);
+            }
+        }
+
+        // uses rounding
+        if (!sighted || sense > 1) {
+
+            int[][] rounding = ShadowCaster.rounding;
+
+            int left, right;
+            int pos;
+            for (int y = Math.max(0, cy - sense); y <= Math.min(height() - 1, cy + sense); y++) {
+                if (rounding[sense][Math.abs(cy - y)] < Math.abs(cy - y)) {
+                    left = cx - rounding[sense][Math.abs(cy - y)];
+                } else {
+                    left = sense;
+                    while (rounding[sense][left] < rounding[sense][Math.abs(cy - y)]) {
+                        left--;
+                    }
+                    left = cx - left;
+                }
+                right = Math.min(width() - 1, cx + cx - left);
+                left = Math.max(0, left);
+                pos = left + y * width();
+                System.arraycopy(discoverable, pos, fieldOfView, pos, right - left + 1);
+            }
+        }
+
+        if (c instanceof SpiritHawk.HawkAlly && Dungeon.hero.pointsInTalent(Talent.EAGLE_EYE) >= 3) {
+            int range = 1 + (Dungeon.hero.pointsInTalent(Talent.EAGLE_EYE) - 2);
+            for (Mob mob : mobs) {
+                int p = mob.pos;
+                if (!fieldOfView[p] && distance(c.pos, p) <= range) {
+                    for (int i : PathFinder.NEIGHBOURS9) {
+                        fieldOfView[mob.pos + i] = true;
+                    }
+                }
+            }
+        }
+
+        // Currently only the hero can get mind vision or awareness
+        if (c.isAlive() && c == Dungeon.hero) {
+
+            if (heroMindFov == null || heroMindFov.length != length()) {
+                heroMindFov = new boolean[length];
+            } else {
+                BArray.setFalse(heroMindFov);
+            }
+
+            Dungeon.hero.mindVisionEnemies.clear();
+            if (c.buff(MindVision.class) != null) {
+                for (Mob mob : mobs) {
+                    for (int i : PathFinder.NEIGHBOURS9) {
+                        heroMindFov[mob.pos + i] = true;
+                    }
+                }
+            } else if (((Hero) c).hasTalent(Talent.HEIGHTENED_SENSES)) {
+                Hero h = (Hero) c;
+                int range = 1 + h.pointsInTalent(Talent.HEIGHTENED_SENSES);
+                for (Mob mob : mobs) {
+                    int p = mob.pos;
+                    if (!fieldOfView[p] && distance(c.pos, p) <= range) {
+                        for (int i : PathFinder.NEIGHBOURS9) {
+                            heroMindFov[mob.pos + i] = true;
+                        }
+                    }
+                }
+            }
+
+            if (c.buff(Awareness.class) != null) {
+                for (Heap heap : heaps.valueList()) {
+                    int p = heap.pos;
+                    for (int i : PathFinder.NEIGHBOURS9)
+                        heroMindFov[p + i] = true;
+                }
+            }
+
+            for (TalismanOfForesight.CharAwareness a : c.buffs(TalismanOfForesight.CharAwareness.class)) {
+                Char ch = (Char) Actor.findById(a.charID);
+                if (ch == null || !ch.isAlive()) {
+                    continue;
+                }
+                int p = ch.pos;
+                for (int i : PathFinder.NEIGHBOURS9)
+                    heroMindFov[p + i] = true;
+            }
+
+            for (TalismanOfForesight.HeapAwareness h : c.buffs(TalismanOfForesight.HeapAwareness.class)) {
+                if (Dungeon.depth != h.depth || Dungeon.branch != h.branch)
+                    continue;
+                for (int i : PathFinder.NEIGHBOURS9)
+                    heroMindFov[h.pos + i] = true;
+            }
+
+            for (Mob m : mobs) {
+                if (m instanceof WandOfWarding.Ward
+                        || m instanceof WandOfRegrowth.Lotus
+                        || m instanceof SpiritHawk.HawkAlly) {
+                    if (m.fieldOfView == null || m.fieldOfView.length != length()) {
+                        m.fieldOfView = new boolean[length()];
+                        Dungeon.level.updateFieldOfView(m, m.fieldOfView);
+                    }
+                    BArray.or(heroMindFov, m.fieldOfView, heroMindFov);
+                }
+            }
+
+            for (RevealedArea a : c.buffs(RevealedArea.class)) {
+                if (Dungeon.depth != a.depth || Dungeon.branch != a.branch)
+                    continue;
+                for (int i : PathFinder.NEIGHBOURS9)
+                    heroMindFov[a.pos + i] = true;
+            }
+
+            // set mind vision chars
+            for (Mob mob : mobs) {
+                if (heroMindFov[mob.pos] && !fieldOfView[mob.pos]) {
+                    Dungeon.hero.mindVisionEnemies.add(mob);
+                }
+            }
+
+            BArray.or(heroMindFov, fieldOfView, fieldOfView);
+
+        }
+
+        if (c == Dungeon.hero) {
+            for (Heap heap : heaps.valueList())
+                if (!heap.seen && fieldOfView[heap.pos])
+                    heap.seen = true;
+        }
+
+    }
+
+    public boolean isLevelExplored(int depth) {
+        return false;
+    }
+
+    public int distance(int a, int b) {
+        int ax = a % width();
+        int ay = a / width();
+        int bx = b % width();
+        int by = b / width();
+        return Math.max(Math.abs(ax - bx), Math.abs(ay - by));
+    }
+
+    public boolean adjacent(int a, int b) {
+        return distance(a, b) == 1;
+    }
+
+    // uses pythagorean theorum for true distance, as if there was no movement grid
+    public float trueDistance(int a, int b) {
+        int ax = a % width();
+        int ay = a / width();
+        int bx = b % width();
+        int by = b / width();
+        return (float) Math.sqrt(Math.pow(Math.abs(ax - bx), 2) + Math.pow(Math.abs(ay - by), 2));
+    }
+
+    // returns true if the input is a valid tile within the level
+    public boolean insideMap(int tile) {
+        // top and bottom row and beyond
+        return !((tile < width || tile >= length - width) ||
+        // left and right column
+                (tile % width == 0 || tile % width == width - 1));
+    }
+
+    public Point cellToPoint(int cell) {
+        return new Point(cell % width(), cell / width());
+    }
+
+    public int pointToCell(Point p) {
+        return p.x + p.y * width();
+    }
+
+    public String tileName(int tile) {
+
+        switch (tile) {
+            case Terrain.CHASM:
+                return Messages.get(Level.class, "chasm_name");
+            case Terrain.EMPTY:
+            case Terrain.EMPTY_SP:
+            case Terrain.EMPTY_DECO:
+            case Terrain.SECRET_TRAP:
+                return Messages.get(Level.class, "floor_name");
+            case Terrain.GRASS:
+                return Messages.get(Level.class, "grass_name");
+            case Terrain.WATER:
+                return Messages.get(Level.class, "water_name");
+            case Terrain.WALL:
+            case Terrain.WALL_DECO:
+            case Terrain.SECRET_DOOR:
+                return Messages.get(Level.class, "wall_name");
+            case Terrain.DOOR:
+                return Messages.get(Level.class, "closed_door_name");
+            case Terrain.OPEN_DOOR:
+                return Messages.get(Level.class, "open_door_name");
+            case Terrain.ENTRANCE:
+                return Messages.get(Level.class, "entrace_name");
+            case Terrain.EXIT:
+                return Messages.get(Level.class, "exit_name");
+            case Terrain.EMBERS:
+                return Messages.get(Level.class, "embers_name");
+            case Terrain.FURROWED_GRASS:
+                return Messages.get(Level.class, "furrowed_grass_name");
+            case Terrain.LOCKED_DOOR:
+                return Messages.get(Level.class, "locked_door_name");
+            case Terrain.CRYSTAL_DOOR:
+                return Messages.get(Level.class, "crystal_door_name");
+            case Terrain.PEDESTAL:
+                return Messages.get(Level.class, "pedestal_name");
+            case Terrain.BARRICADE:
+                return Messages.get(Level.class, "barricade_name");
+            case Terrain.HIGH_GRASS:
+                return Messages.get(Level.class, "high_grass_name");
+            case Terrain.LOCKED_EXIT:
+                return Messages.get(Level.class, "locked_exit_name");
+            case Terrain.UNLOCKED_EXIT:
+                return Messages.get(Level.class, "unlocked_exit_name");
+            case Terrain.SIGN:
+                return Messages.get(Level.class, "sign_name");
+            case Terrain.WELL:
+                return Messages.get(Level.class, "well_name");
+            case Terrain.EMPTY_WELL:
+                return Messages.get(Level.class, "empty_well_name");
+            case Terrain.STATUE:
+            case Terrain.STATUE_SP:
+                return Messages.get(Level.class, "statue_name");
+            case Terrain.INACTIVE_TRAP:
+                return Messages.get(Level.class, "inactive_trap_name");
+            case Terrain.BOOKSHELF:
+                return Messages.get(Level.class, "bookshelf_name");
+            case Terrain.ALCHEMY:
+                return Messages.get(Level.class, "alchemy_name");
+            default:
+                return Messages.get(Level.class, "default_name");
+        }
+    }
+
+    public String tileDesc(int tile) {
+
+        switch (tile) {
+            case Terrain.CHASM:
+                return Messages.get(Level.class, "chasm_desc");
+            case Terrain.WATER:
+                return Messages.get(Level.class, "water_desc");
+            case Terrain.ENTRANCE:
+                return Messages.get(Level.class, "entrance_desc");
+            case Terrain.EXIT:
+            case Terrain.UNLOCKED_EXIT:
+                return Messages.get(Level.class, "exit_desc");
+            case Terrain.EMBERS:
+                return Messages.get(Level.class, "embers_desc");
+            case Terrain.HIGH_GRASS:
+            case Terrain.FURROWED_GRASS:
+                return Messages.get(Level.class, "high_grass_desc");
+            case Terrain.LOCKED_DOOR:
+                return Messages.get(Level.class, "locked_door_desc");
+            case Terrain.CRYSTAL_DOOR:
+                return Messages.get(Level.class, "crystal_door_desc");
+            case Terrain.LOCKED_EXIT:
+                return Messages.get(Level.class, "locked_exit_desc");
+            case Terrain.BARRICADE:
+                return Messages.get(Level.class, "barricade_desc");
+            case Terrain.SIGN:
+                return Messages.get(Level.class, "sign_desc");
+            case Terrain.INACTIVE_TRAP:
+                return Messages.get(Level.class, "inactive_trap_desc");
+            case Terrain.STATUE:
+            case Terrain.STATUE_SP:
+                return Messages.get(Level.class, "statue_desc");
+            case Terrain.ALCHEMY:
+                return Messages.get(Level.class, "alchemy_desc");
+            case Terrain.EMPTY_WELL:
+                return Messages.get(Level.class, "empty_well_desc");
+            default:
+                return "";
+        }
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/Level.java
@@ -922,7 +922,6 @@ public abstract class Level implements Bundlable {
     public Heap drop(Item item, int cell) {
 
         if (item == null || Challenges.isItemBlocked(item)) {
-
             // create a dummy heap, give it a dummy sprite, don't add it to the game, and
             // return it.
             // effectively nullifies whatever the logic calling this wants to do, including
@@ -931,7 +930,6 @@ public abstract class Level implements Bundlable {
             ItemSprite sprite = heap.sprite = new ItemSprite();
             sprite.link(heap);
             return heap;
-
         }
 
         Heap heap = heaps.get(cell);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/features/HighGrass.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/features/HighGrass.java
@@ -116,7 +116,7 @@ public class HighGrass {
 
                         if (droppingBerry) {
                             dropped.countUp(1);
-                            level.drop(new Berry(), pos).sprite.drop();
+                            level.drop(new Berry(), pos, true).sprite.drop();
                         }
                     }
 


### PR DESCRIPTION
Implements auto-loot that triggers when walking over items that lie on the floor. This includes items that were just dropped on the hero's position, if certain conditions apply:
- the item was not dropped by the hero himself
- the item was not dropped due to insufficient space in the hero's inventory
- the item is not some sort of ammunition or similar from other entites
- the item is a dewdrop or similar dropped when trampling grass

Many parts in the code put the item into the inventory directly, without dropping it and showing an animation. That is not what we want to do. Auto-looting some items should still show the animation of looting. That would imply that it has to be dropped first before being able to be picked up. 

# DONE
- auto-looting dewdrops, berries, and seeds when high grass is trampled
- auto-looting all items on a heap, and not only the fist one the stack
- auto-looting when walking over items on the floor
- auto-looting specific items dropped onto the hero's position